### PR TITLE
fix: support empty base in vite options

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ export function slash(str: string) {
 export function resolveBathPath(base: string) {
   if (isAbsolute(base))
     return base
-  return !base.startsWith('/') && !base.startsWith('./')
+  return base && !base.startsWith('/') && !base.startsWith('./')
     ? `/${base}`
     : base
 }


### PR DESCRIPTION
vite supports an [empty string](https://vitejs.dev/config/#base) for `base`, but if `base: ''` then VitePWA injects a manifest link to `/manifest.webmanifest`, instead of `manifest.webmanifest`. This fixes that :)