### PR TITLE
fix(dev): 404 workbox-*.js when base option exists

### DIFF
--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -155,7 +155,9 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
           }
           return await fs.readFile(swDest, 'utf-8')
         }
-        const key = normalizePath(`${options.base}${id.substring(1)}`);
+        
+        const key = normalizePath(`${options.base}${id.startsWith('/') ? id.slice(1) : id}`)
+
         if (swDevOptions.workboxPaths.has(key))
           return await fs.readFile(swDevOptions.workboxPaths.get(key)!, 'utf-8')
       }

--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -155,9 +155,9 @@ export function DevPlugin(ctx: PWAPluginContext): Plugin {
           }
           return await fs.readFile(swDest, 'utf-8')
         }
-
-        if (swDevOptions.workboxPaths.has(id))
-          return await fs.readFile(swDevOptions.workboxPaths.get(id)!, 'utf-8')
+        const key = normalizePath(`${options.base}${id.substring(1)}`);
+        if (swDevOptions.workboxPaths.has(key))
+          return await fs.readFile(swDevOptions.workboxPaths.get(key)!, 'utf-8')
       }
     },
   }


### PR DESCRIPTION
request for `registerSW.js` and `workbox-*.js` is 404 when vite `base` option is not empty.(eg `/pdf-annotate/`)

<img width="1630" alt="image" src="https://user-images.githubusercontent.com/5358537/194738987-bd069c70-7a7e-4eaa-89ba-3db1d17daa2e.png">
