### PR TITLE
docs: unregister docs from the plugin repo

### DIFF
--- a/docs/scripts/pwa.ts
+++ b/docs/scripts/pwa.ts
@@ -5,6 +5,7 @@ export const pwa = () => {
     outDir: '.vitepress/dist',
     registerType: 'prompt',
     includeManifestIcons: false,
+    selfDestroying: true,
     manifest: {
       id: '/',
       name: 'Vite Plugin PWA',


### PR DESCRIPTION
Since the rdirection to the new docs is already configured, we only need to add `selfDestroying` to the docs here, then on reload and once the pwa is deleted from the client, users will be redirected to the new docs.

This PR will be on draft until I merge and publish `v0.13.4` with my 3 last pending PR and the integrations also released.

We need to add a new entry in the new docs repo about the pwa info virtual module, I'll send a PR later.

Once we have `v0.13.4` and the integrations, we can merge this PR, we shouldn't remove the docs from here, but we need to freeze it (we also need to keep it on netlify or ppl won't be able to uninstall the old PWA, maybe in a future we can remove it also from netlify).

/cc @antfu  (sorry for the ping)