### PR TITLE
feat: split client type definitions

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -22,3 +22,168 @@ declare module 'virtual:pwa-register' {
 
   export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
 }
+
+declare module 'virtual:pwa-register/vue' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when vue is not installed
+  import type { Ref } from 'vue'
+
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: Ref<boolean>
+    offlineReady: Ref<boolean>
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
+}
+
+declare module 'virtual:pwa-register/svelte' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when svelte is not installed
+  import type { Writable } from 'svelte/store'
+
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: Writable<boolean>
+    offlineReady: Writable<boolean>
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
+}
+
+declare module 'virtual:pwa-register/react' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when react is not installed
+  import type { Dispatch, SetStateAction } from 'react'
+
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [boolean, Dispatch<SetStateAction<boolean>>]
+    offlineReady: [boolean, Dispatch<SetStateAction<boolean>>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
+}
+
+declare module 'virtual:pwa-register/solid' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when solid-js is not installed
+  import type { Accessor, Setter } from 'solid-js'
+
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [Accessor<boolean>, Setter<boolean>]
+    offlineReady: [Accessor<boolean>, Setter<boolean>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
+}
+
+declare module 'virtual:pwa-register/preact' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when preact/hooks is not installed
+  import type { StateUpdater } from 'preact/hooks'
+
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [boolean, StateUpdater<boolean>]
+    offlineReady: [boolean, StateUpdater<boolean>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
+}

--- a/examples/preact-router/src/vite-env.d.ts
+++ b/examples/preact-router/src/vite-env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/client" />
+/// <reference types="vite-plugin-pwa/preact" />

--- a/examples/preact-router/tsconfig.json
+++ b/examples/preact-router/tsconfig.json
@@ -17,7 +17,7 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "types": ["vite/client", "vite-plugin-pwa", "vite-plugin-pwa/client"]
+    "types": ["vite/client", "vite-plugin-pwa", "vite-plugin-pwa/preact"]
   },
   "include": ["src"]
 }

--- a/examples/react-router/src/vite-env.d.ts
+++ b/examples/react-router/src/vite-env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/client" />
+/// <reference types="vite-plugin-pwa/react" />

--- a/examples/react-router/tsconfig.json
+++ b/examples/react-router/tsconfig.json
@@ -16,7 +16,7 @@
     "jsx": "react",
     "types": [
       "vite-plugin-pwa",
-      "vite-plugin-pwa/client"
+      "vite-plugin-pwa/react"
     ]
   },
   "include": ["./src"]

--- a/examples/solid-router/tsconfig.json
+++ b/examples/solid-router/tsconfig.json
@@ -8,6 +8,6 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client", "vite-plugin-pwa", "vite-plugin-pwa/client"]
+    "types": ["vite/client", "vite-plugin-pwa", "vite-plugin-pwa/solid"]
   }
 }

--- a/examples/svelte-routify/src/vite-env.d.ts
+++ b/examples/svelte-routify/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/client" />
+/// <reference types="vite-plugin-pwa/svelte" />

--- a/examples/svelte-routify/tsconfig.json
+++ b/examples/svelte-routify/tsconfig.json
@@ -15,7 +15,7 @@
     "allowJs": true,
     "checkJs": true,
     "types": [
-      "vite-plugin-pwa/client"
+      "vite-plugin-pwa/svelte"
     ]
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -1,4 +1,8 @@
-declare module 'virtual:pwa-register' {
+declare module 'virtual:pwa-register/preact' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when preact/hooks is not installed
+  import type { StateUpdater } from 'preact/hooks'
+
   export interface RegisterSWOptions {
     immediate?: boolean
     onNeedRefresh?: () => void
@@ -20,5 +24,9 @@ declare module 'virtual:pwa-register' {
     onRegisterError?: (error: any) => void
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [boolean, StateUpdater<boolean>]
+    offlineReady: [boolean, StateUpdater<boolean>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
 }

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,4 +1,8 @@
-declare module 'virtual:pwa-register' {
+declare module 'virtual:pwa-register/react' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when react is not installed
+  import type { Dispatch, SetStateAction } from 'react'
+
   export interface RegisterSWOptions {
     immediate?: boolean
     onNeedRefresh?: () => void
@@ -20,5 +24,9 @@ declare module 'virtual:pwa-register' {
     onRegisterError?: (error: any) => void
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [boolean, Dispatch<SetStateAction<boolean>>]
+    offlineReady: [boolean, Dispatch<SetStateAction<boolean>>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
 }

--- a/solid.d.ts
+++ b/solid.d.ts
@@ -1,4 +1,8 @@
-declare module 'virtual:pwa-register' {
+declare module 'virtual:pwa-register/solid' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when solid-js is not installed
+  import type { Accessor, Setter } from 'solid-js'
+
   export interface RegisterSWOptions {
     immediate?: boolean
     onNeedRefresh?: () => void
@@ -20,5 +24,9 @@ declare module 'virtual:pwa-register' {
     onRegisterError?: (error: any) => void
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: [Accessor<boolean>, Setter<boolean>]
+    offlineReady: [Accessor<boolean>, Setter<boolean>]
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
 }

--- a/svelte.d.ts
+++ b/svelte.d.ts
@@ -1,4 +1,8 @@
-declare module 'virtual:pwa-register' {
+declare module 'virtual:pwa-register/svelte' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when svelte is not installed
+  import type { Writable } from 'svelte/store'
+
   export interface RegisterSWOptions {
     immediate?: boolean
     onNeedRefresh?: () => void
@@ -20,5 +24,9 @@ declare module 'virtual:pwa-register' {
     onRegisterError?: (error: any) => void
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: Writable<boolean>
+    offlineReady: Writable<boolean>
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
 }

--- a/vanillajs.d.ts
+++ b/vanillajs.d.ts
@@ -1,0 +1,24 @@
+declare module 'virtual:pwa-register' {
+  export interface RegisterSWOptions {
+    immediate?: boolean
+    onNeedRefresh?: () => void
+    onOfflineReady?: () => void
+    /**
+     * Called only if `onRegisteredSW` is not provided.
+     *
+     * @deprecated Use `onRegisteredSW` instead.
+     * @param registration The service worker registration if available.
+     */
+    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    /**
+     * Called once the service worker is registered (requires version `0.12.8+`).
+     *
+     * @param swScriptUrl The service worker script url.
+     * @param registration The service worker registration if available.
+     */
+    onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
+    onRegisterError?: (error: any) => void
+  }
+
+  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+}

--- a/vue.d.ts
+++ b/vue.d.ts
@@ -1,4 +1,8 @@
-declare module 'virtual:pwa-register' {
+declare module 'virtual:pwa-register/vue' {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore ignore when vue is not installed
+  import type { Ref } from 'vue'
+
   export interface RegisterSWOptions {
     immediate?: boolean
     onNeedRefresh?: () => void
@@ -20,5 +24,9 @@ declare module 'virtual:pwa-register' {
     onRegisterError?: (error: any) => void
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function useRegisterSW(options?: RegisterSWOptions): {
+    needRefresh: Ref<boolean>
+    offlineReady: Ref<boolean>
+    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+  }
 }


### PR DESCRIPTION
@yoyo930021 can you check with a local copy?

You will need to change `d.ts` or `tsconfig.json` to use:
```ts 
/// <reference types="vite-plugin-pwa/react" />
```
or (`tsconfig.json`)
```json
"types": ["vite-plugin-pwa/react"]
```

EDIT: your packages are using `vite-plugin-pwa/client`, I just move each fw to its own dts and remove all fw definitions from `client.d.ts`.

closes #409