### PR TITLE
feat: support rollup assets file names

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -85,7 +85,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     swSrc,
     swDest,
     globDirectory: outDirRoot,
-    dontCacheBustURLsMatching: /[.-].[a-f0-9]{8}\./,
+    dontCacheBustURLsMatching: /[.-][a-f0-9]{8}\./,
     injectionPoint: 'self.__WB_MANIFEST',
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -76,7 +76,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     globDirectory: outDirRoot,
     offlineGoogleAnalytics: false,
     cleanupOutdatedCaches: true,
-    dontCacheBustURLsMatching: /\.[a-f0-9]{8}\./,
+    dontCacheBustURLsMatching: /[.-][a-f0-9]{8}\./,
     mode,
     navigateFallback: 'index.html',
   }
@@ -85,7 +85,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     swSrc,
     swDest,
     globDirectory: outDirRoot,
-    dontCacheBustURLsMatching: /\.[a-f0-9]{8}\./,
+    dontCacheBustURLsMatching: /[.-].[a-f0-9]{8}\./,
     injectionPoint: 'self.__WB_MANIFEST',
   }
 


### PR DESCRIPTION
By default `dontCacheBustURLsMatching` is using Vite assets file names (`<name>.<hash>.<ext>`) and  it will change to align it with Rollup default assets naming (`<name>-<hash>.<ext>`): https://github.com/vitejs/vite/pull/10878.

This PR just changes the regex to support both layouts.