### PR TITLE
feat: add share_target to manifest

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,11 @@ export interface ResolvedVitePWAOptions extends Required<VitePWAOptions> {
   vitePlugins: InjectManifestVitePlugins
 }
 
+export interface ShareTargetFiles {
+  name: string
+  accept: string
+}
+
 export interface ManifestOptions {
   /**
    * @default _npm_package_name_
@@ -286,10 +291,7 @@ export interface ManifestOptions {
       title?: string
       text?: string
       url?: string
-      files?: {
-        name: string
-        accept: string | string[]
-      }[]
+      files?: ShareTargetFiles | ShareTargetFiles[]
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,20 @@ export interface ManifestOptions {
    * @default ''
    */
   iarc_rating_id: string
+  share_target: {
+    action: string
+    method?: string
+    enctype?: string
+    params: {
+      title?: string
+      text?: string
+      url?: string
+      files?: {
+        name: string
+        accept: string | string[]
+      }[]
+    }
+  }
 }
 
 export interface WebManifestData {


### PR DESCRIPTION
Add [share_target](https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target)~~, `files` will be an array~~.