### PR TITLE
fix: use build base on virtual module

### DIFF
--- a/examples/vanilla-ts-dev-options/package.json
+++ b/examples/vanilla-ts-dev-options/package.json
@@ -10,6 +10,9 @@
     "dev-inline-destroy": "rimraf dev-dist && cross-env DEBUG=vite-plugin-pwa:* SW_DEV=true SW_DESTROY=true SW_INLINE=inline vite --force",
     "dev-script-destroy": "rimraf dev-dist && cross-env DEBUG=vite-plugin-pwa:* SW_DEV=true SW_DESTROY=true SW_INLINE=script vite --force",
     "build": "cross-env DEBUG=vite-plugin-pwa:* vite build",
+    "build-auto": "rimraf dev-dist && cross-env DEBUG=vite-plugin-pwa:* SW_DEV=true SW_INLINE=auto vite build --force",
+    "build-inline": "rimraf dev-dist && cross-env DEBUG=vite-plugin-pwa:* SW_DEV=true SW_INLINE=inline vite build --force",
+    "build-script": "rimraf dev-dist && cross-env DEBUG=vite-plugin-pwa:* SW_DEV=true SW_INLINE=script vite build --force",
     "serve": "serve dist"
   },
   "devDependencies": {

--- a/examples/vanilla-ts-dev-options/vite.config.ts
+++ b/examples/vanilla-ts-dev-options/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     VitePWA({
       mode: 'development',
       base: '/',
+      /* buildBase: '/test-build-base/', */
       includeAssets: ['favicon.svg'],
       injectRegister,
       selfDestroying,

--- a/examples/vanilla-ts-no-ip/vite.config.ts
+++ b/examples/vanilla-ts-no-ip/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     VitePWA({
       mode: 'development',
       base: '/',
+      /* buildBase: '/test-build-base/', */
       strategies: 'injectManifest',
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg'],

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -39,7 +39,7 @@ async function loadRollupReplacePlugin() {
 }
 
 export async function generateRegisterSW(options: ResolvedVitePWAOptions, mode: 'build' | 'dev', source = 'register') {
-  const sw = options.base + options.filename
+  const sw = options.buildBase + options.filename
   const scope = options.scope
 
   const content = await fs.readFile(resolve(_dirname, `client/${mode}/${source}.mjs`), 'utf-8')


### PR DESCRIPTION
This PR also replaces `'__SW__'` with `buildBase`, if missing it is initialized with `baseBuild`, check https://github.com/vite-pwa/vite-plugin-pwa/blob/main/src/options.ts#L161