### PR TITLE
fix: support "types" condition in "exports" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,12 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
+    "./client": {
+      "types": "./client.d.ts"
+    },
+    "./info": {
+      "types": "./info.d.ts"
+    },
     "./*": "./*"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
If typescript uses "exports" field for resolution, it will ignore all other resolutions, so I have this error with the `bundler` `moduleResolution`:

```
error TS2688: Cannot find type definition file for 'vite-plugin-pwa/client'.
  The file is in the program because:
    Entry point of type library 'vite-plugin-pwa/client' specified in compilerOptions

  tsconfig.json:9:7
    9       "vite-plugin-pwa/client"
            ~~~~~~~~~~~~~~~~~~~~~~~~
    File is entry point of type library specified here.
```

https://arethetypeswrong.github.io