### PR TITLE
fix: Make manifest.shortcuts.icons optional #509

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -275,7 +275,7 @@ export interface ManifestOptions {
     short_name?: string
     url: string
     description?: string
-    icons: Record<string, any>[]
+    icons?: Record<string, any>[]
   }[]
   /**
    * @default []


### PR DESCRIPTION
Fixes https://github.com/vite-pwa/vite-plugin-pwa/issues/509