### PR TITLE
feat: Allow suppress workbox-build warnings in dev

### DIFF
--- a/examples/vue-router/vite.config.ts
+++ b/examples/vue-router/vite.config.ts
@@ -36,6 +36,7 @@ const pwaOptions: Partial<VitePWAOptions> = {
     /* when using generateSW the PWA plugin will switch to classic */
     type: 'module',
     navigateFallback: 'index.html',
+    suppressWarnings: true,
   },
 }
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execSync } from 'node:child_process'
 import { commands } from './commands'
 
 for (const command of commands)

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn } from 'node:child_process'
 import { commands } from './commands'
 
 for (const command of commands)

--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execSync } from 'node:child_process'
 import prompts from 'prompts'
 import {
   blue,

--- a/src/options.ts
+++ b/src/options.ts
@@ -54,7 +54,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     includeManifestIcons = true,
     useCredentials = false,
     disable = false,
-    devOptions = { enabled: false, type: 'classic' },
+    devOptions = { enabled: false, type: 'classic', suppressWarnings: false },
     selfDestroying = false,
     integration = {},
     buildBase,

--- a/src/types.ts
+++ b/src/types.ts
@@ -465,6 +465,17 @@ export interface DevOptions {
    * Where to store generated service worker in development when using `generateSW` strategy.
    *
    * Use it with caution, it should be used only by framework integrations.
+   *
+   * @default resolve(viteConfig.root, 'dev-dist')
    */
   resolveTempFolder?: () => string | Promise<string>
+  /**
+   * Suppress workbox-build warnings?.
+   *
+   * **WARNING**: this option will only be used when using `generateSW` strategy.
+   * If enabled, `globPatterns` will be changed to `[*.js]` and a new empty `suppress-warnings.js` file will be created in .
+   *
+   * @default false
+   */
+  suppressWarnings?: boolean
 }


### PR DESCRIPTION
Requires enable `devOptions.suppressWarnings = true`.

closes #436