### PR TITLE
Fix wrong manifest file path

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -65,6 +65,7 @@ export async function configureStaticAssets(
     includeAssets,
     includeManifestIcons,
     manifestFilename,
+    buildBase,
   } = resolvedVitePWAOptions
 
   const useInjectManifest = strategies === 'injectManifest'
@@ -116,7 +117,7 @@ export async function configureStaticAssets(
     const cHash = crypto.createHash('MD5')
     cHash.update(generateWebManifestFile(resolvedVitePWAOptions))
     manifestEntries.push({
-      url: manifestFilename,
+      url: buildBase + manifestFilename,
       revision: `${cHash.digest('hex')}`,
     })
   }


### PR DESCRIPTION
Issue: I've encountered an issue with the `manifest.webmanifest` file that is added to pre-cache even in `injectManifest` mode. I'm using a Laravel setup, so the webmanifest is built to `/build/`. If I change `manifestFilename` to `/build/manifest.webmanifest`, it will output the file into `/build/build/manifest.webmanifest`.

Looking at the source code here it is impossible to disable this behavior - I would appreciate the option to simply disable the automatic inclusion of wrong files into pre-cache. (Also, it seems quite excessive to re-generate the whole manifest file just to create the hash, but that's just a performance issue) https://github.com/vite-pwa/vite-plugin-pwa/blob/31ccaa89bb18b7d39f8d150435b26d33dfee04dd/src/assets.ts#L115-L129 

Therefore, I added `buildBase` to the manifest file that always gets added to `additionalManifestEntries`, now it generates the correct path and pre-cache doesn't fail anymore.

To be frank: I haven't tested this with any other setup, but from looking at the code I'm rather confident this is a bug in the plugin and not in the setup. If the issue is resolved in another way I wouldn't bother. I've simply spent too much time trying to figure out why `manifest.webmanifest` is added to pre-cache when this plugin outputs the manifest to `build/manifest.webmanifest`. 