### PR TITLE
feat(types): allow `scope_extensions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -350,6 +350,13 @@ export interface ManifestOptions {
   edge_side_panel?: {
     preferred_width?: number
   }
+  /**
+   * https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md
+   * @default []
+   */
+  scope_extensions: {
+    origin: string
+  }[]
 }
 
 export interface WebManifestData {


### PR DESCRIPTION
Scope extensions are currently part of the manifest incubation: https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md