### PR TITLE
feat: add missing `screenshots.form_factor` and fix wrong `screenshots.platform` options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -312,7 +312,8 @@ export interface ManifestOptions {
     src: string
     sizes: string
     label?: string
-    platform?: 'narrow' | 'wide' | 'android' | 'ios' | 'kaios' | 'macos' | 'windows' | 'windows10x' | 'chrome_web_store' | 'play' | 'itunes' | 'microsoft-inbox' | 'microsoft-store' | string
+    platform?: 'android' | 'ios' | 'kaios' | 'macos' | 'windows' | 'windows10x' | 'chrome_web_store' | 'play' | 'itunes' | 'microsoft-inbox' | 'microsoft-store' | string
+    form_factor?: 'narrow' | 'wide'
     type?: string
   }[]
   /**


### PR DESCRIPTION
`narrow` and `wide` are specified to be part of `form_factor`, not `platform`: https://w3c.github.io/manifest-app-info/#form_factor-member