### PR TITLE
chore: update examples including tsconfig and type module

### DIFF
--- a/examples/preact-router/package.json
+++ b/examples/preact-router/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-preact-router",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/preact-router/tsconfig.json
+++ b/examples/preact-router/tsconfig.json
@@ -1,23 +1,26 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
-    "allowJs": false,
-    "skipLibCheck": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "WebWorker"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment",
-    "types": ["vite/client", "vite-plugin-pwa/client", "vite-plugin-pwa/info"]
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/examples/preact-router/tsconfig.node.json
+++ b/examples/preact-router/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -1,6 +1,7 @@
 {
   "name": "example-react-router",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "scripts": {
     "dev": "rimraf dev-dist && DEBUG=vite-plugin-pwa SW_DEV=true vite --force",

--- a/examples/react-router/tsconfig.node.json
+++ b/examples/react-router/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/solid-router/package.json
+++ b/examples/solid-router/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-solid-router",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/solid-router/src/vite-env.d.ts
+++ b/examples/solid-router/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/preact" />
 /// <reference types="vite-plugin-pwa/info" />
+/// <reference types="vite-plugin-pwa/solid" />

--- a/examples/solid-router/tsconfig.json
+++ b/examples/solid-router/tsconfig.json
@@ -1,13 +1,26 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["WebWorker"],
+    "target": "ES2020",
+    "useDefineForClassFields": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "WebWorker"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client", "vite-plugin-pwa/info", "vite-plugin-pwa/solid"]
-  }
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/examples/solid-router/tsconfig.node.json
+++ b/examples/solid-router/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/svelte-routify/tsconfig.json
+++ b/examples/svelte-routify/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
     "resolveJsonModule": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "5.0",
-    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
+
     /**
-      * Typecheck JS in `.svelte` and `.js` files by default.
-      * Disable checkJs if you'd like to use dynamic types in JS.
-      * Note that setting allowJs false does not prevent the use
-      * of JS in `.svelte` files.
-      */
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
     "allowJs": true,
     "checkJs": true,
+    "isolatedModules": true
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/examples/svelte-routify/tsconfig.node.json
+++ b/examples/svelte-routify/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/vanilla-ts-dev-options/package.json
+++ b/examples/vanilla-ts-dev-options/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vanilla-ts-dev-options",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/vanilla-ts-dev-options/tsconfig.json
+++ b/examples/vanilla-ts-dev-options/tsconfig.json
@@ -1,21 +1,24 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
-    "strict": true,
-    "sourceMap": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "types": ["vite/client", "vite-plugin-pwa/vanillajs", "vite-plugin-pwa/info"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
     "noEmit": true,
+
+    /* Linting */
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "skipLibCheck": true,
-    "types": ["vite-plugin-pwa/vanillajs", "vite-plugin-pwa/info"]
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]
 }

--- a/examples/vanilla-ts-no-ip/package.json
+++ b/examples/vanilla-ts-no-ip/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vanilla-ts-no-ip",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/vanilla-ts-no-ip/tsconfig.json
+++ b/examples/vanilla-ts-no-ip/tsconfig.json
@@ -1,21 +1,24 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ESNext", "DOM", "WebWorker"],
-    "moduleResolution": "Node",
-    "strict": true,
-    "sourceMap": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "WebWorker"],
+    "skipLibCheck": true,
+    "types": ["vite/client", "vite-plugin-pwa/vanillajs", "vite-plugin-pwa/info"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
     "noEmit": true,
+
+    /* Linting */
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "skipLibCheck": true,
-    "types": ["vite/client", "vite-plugin-pwa/vanillajs", "vite-plugin-pwa/info"]
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src"]
 }

--- a/examples/vue-basic-cdn/package.json
+++ b/examples/vue-basic-cdn/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-vue-basic",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/vue-basic-cdn/tsconfig.json
+++ b/examples/vue-basic-cdn/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable", "WebWorker"],
     "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
 
     /* Linting */
     "strict": true,
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/examples/vue-basic-cdn/tsconfig.node.json
+++ b/examples/vue-basic-cdn/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-vue-router",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/vue-router/src/vite-env.d.ts
+++ b/examples/vue-router/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/preact" />
 /// <reference types="vite-plugin-pwa/info" />
+/// <reference types="vite-plugin-pwa/vue" />

--- a/examples/vue-router/tsconfig.json
+++ b/examples/vue-router/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable", "WebWorker"],
     "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
 
     /* Linting */
     "strict": true,
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/examples/vue-router/tsconfig.node.json
+++ b/examples/vue-router/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "test-preact": "pnpm -C examples/preact-router run test",
     "test-solid": "pnpm -C examples/solid-router run test",
     "test-svelte": "pnpm -C examples/svelte-routify run test",
-    "test-typescrypt": "pnpm -C examples/vanilla-ts-no-ip run test",
-    "test": "nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-svelte && nr test-typescrypt",
-    "test:vite-ecosystem-ci": "nr test-typescrypt"
+    "test-typescript": "pnpm -C examples/vanilla-ts-no-ip run test",
+    "test": "nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-svelte && nr test-typescript",
+    "test:vite-ecosystem-ci": "nr test-typescript"
   },
   "peerDependencies": {
     "vite": "^3.1.0 || ^4.0.0",


### PR DESCRIPTION
This PR includes the tsconfig from create-vite (tsconfig.node.json + tsconfig.json updates) using bundler and updating all examples to use type module.

It took a while testing all examples including CJS.