### PR TITLE
Allow custom modes beyond production or development

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -99,8 +99,8 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
   await build({
     root: viteOptions.root,
     base: viteOptions.base,
-    // don't copy anything from public folder
     resolve: viteOptions.resolve,
+    // don't copy anything from public folder
     mode: options.mode,
     publicDir: false,
     build: {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -99,6 +99,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
   await build({
     root: viteOptions.root,
     base: viteOptions.base,
+    // don't copy anything from public folder
     resolve: viteOptions.resolve,
     mode: options.mode,
     publicDir: false,

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -100,7 +100,7 @@ export async function generateInjectManifest(options: ResolvedVitePWAOptions, vi
     root: viteOptions.root,
     base: viteOptions.base,
     resolve: viteOptions.resolve,
-    // don't copy anything from public folder
+    mode: options.mode,
     publicDir: false,
     build: {
       sourcemap: viteOptions.build.sourcemap,

--- a/src/options.ts
+++ b/src/options.ts
@@ -41,7 +41,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
   const {
     // prevent tsup replacing `process.env`
     // eslint-disable-next-line dot-notation
-    mode = (process['env']['NODE_ENV'] || 'production') as ('production' | 'development'),
+    mode = (process['env']['NODE_ENV'] || 'production'),
     srcDir = 'public',
     outDir = viteConfig.build.outDir || 'dist',
     injectRegister = 'auto',

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface VitePWAOptions {
    *
    * @default process.env.NODE_ENV or "production"
    */
-  mode?: 'development' | 'production'
+  mode?: 'development' | 'production' | string
   /**
    * @default 'public'
    */


### PR DESCRIPTION
I noticed the necessity for this PR when I saw that my `sw-main.js` showed a different value for `import.meta.env.MODE` than my regular `main.js` after running `vite build --mode staging`. `sw-main.js` showed `production` while `main.js` showed `staging`.

This PR is an attempt to bring the `vite-plugin-pwa` configs a bit more inline with the [vite docs](https://vitejs.dev/guide/env-and-mode.html#modes) when it comes to modes. With this PR, modes can go beyond `production` and `development`. While `process.env.NODE_ENV` is a perfectly useful escape hatch, I believe defaulting the service worker's value for `mode` to the same value as the rest of the app will be more intuitive. We achieve this by:

a) No longer limiting the `mode` type to `production` | `development`, but also including `string`. We could also technically just do `string`, but including the literals could be a slightly better developer experience.

b) Actually passing the `options.mode` value down to `vite.build`.

c) Preserving the `process.node.env` escape hatch for backwards compatibility.