### PR TITLE
feat: update type definitions for `manifest` options

### DIFF
--- a/examples/vue-router/vite.config.ts
+++ b/examples/vue-router/vite.config.ts
@@ -28,7 +28,7 @@ const pwaOptions: Partial<VitePWAOptions> = {
         src: 'pwa-512x512.png', // <== don't add slash, for testing
         sizes: '512x512',
         type: 'image/png',
-        purpose: 'any maskable',
+        purpose: ['any', 'maskable'], // testing new type declaration
       },
     ],
   },

--- a/src/options.ts
+++ b/src/options.ts
@@ -135,6 +135,30 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
     devOptions.type = 'classic'
   }
 
+  // convert icons' purpose
+  if (manifest) {
+    if (manifest.icons) {
+      manifest.icons = manifest.icons.map((icon) => {
+        if (icon.purpose && Array.isArray(icon.purpose))
+          icon.purpose = icon.purpose.join(' ')
+
+        return icon
+      })
+    }
+    if (manifest.shortcuts) {
+      manifest.shortcuts.forEach((shortcut) => {
+        if (shortcut.icons) {
+          shortcut.icons = shortcut.icons.map((icon) => {
+            if (icon.purpose && Array.isArray(icon.purpose))
+              icon.purpose = icon.purpose.join(' ')
+
+            return icon
+          })
+        }
+      })
+    }
+  }
+
   const resolvedVitePWAOptions: ResolvedVitePWAOptions = {
     base: basePath,
     mode,

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,7 +227,12 @@ export interface ManifestOptions {
   /**
    *
    */
-  icons: Array<Record<'sizes' | 'src' | 'type', string> & { purpose?: 'monochrome' | 'maskable' | 'any' }>
+  icons: {
+    sizes?: string
+    src: string
+    type?: string
+    purpose?: 'monochrome' | 'maskable' | 'any'
+  }[]
   /**
    *
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,7 +339,7 @@ export interface ManifestOptions {
   iarc_rating_id: string
   share_target: {
     action: string
-    method?: string
+    method?: 'GET' | 'POST'
     enctype?: string
     params: {
       title?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,7 +311,12 @@ export interface ManifestOptions {
     short_name?: string
     url: string
     description?: string
-    icons?: Record<string, any>[]
+    icons?: {
+      sizes?: string
+      src: string
+      type?: string
+      purpose?: 'monochrome' | 'maskable' | 'any'
+    }[]
   }[]
   /**
    * @default []

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,11 +251,11 @@ export interface ManifestOptions {
   /**
    * @default `standalone`
    */
-  display: string
+  display: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
   /**
    * @default []
    */
-  display_override: string[]
+  display_override: Array<'fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay'>
   /**
    * @default `#ffffff`
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,13 @@ export interface ShareTargetFiles {
  */
 export type LaunchHandlerClientMode = 'auto' | 'focus-existing' | 'navigate-existing' | 'navigate-new'
 
+export interface IconResource {
+  sizes?: string
+  src: string
+  type?: string
+  purpose?: 'monochrome' | 'maskable' | 'any'
+}
+
 export interface ManifestOptions {
   /**
    * @default _npm_package_name_
@@ -227,12 +234,7 @@ export interface ManifestOptions {
   /**
    *
    */
-  icons: {
-    sizes?: string
-    src: string
-    type?: string
-    purpose?: 'monochrome' | 'maskable' | 'any'
-  }[]
+  icons: IconResource[]
   /**
    *
    */
@@ -311,12 +313,7 @@ export interface ManifestOptions {
     short_name?: string
     url: string
     description?: string
-    icons?: {
-      sizes?: string
-      src: string
-      type?: string
-      purpose?: 'monochrome' | 'maskable' | 'any'
-    }[]
+    icons?: IconResource[]
   }[]
   /**
    * @default []

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,7 +227,7 @@ export interface ManifestOptions {
   /**
    *
    */
-  icons: Record<string, any>[]
+  icons: Array<Record<'sizes' | 'src' | 'type', string> & { purpose: 'monochrome' | 'maskable' | 'any' }>
   /**
    *
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,7 +227,7 @@ export interface ManifestOptions {
   /**
    *
    */
-  icons: Array<Record<'sizes' | 'src' | 'type', string> & { purpose: 'monochrome' | 'maskable' | 'any' }>
+  icons: Array<Record<'sizes' | 'src' | 'type', string> & { purpose?: 'monochrome' | 'maskable' | 'any' }>
   /**
    *
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,10 +207,13 @@ export interface ShareTargetFiles {
 }
 
 /**
- * https://developer.mozilla.org/en-US/docs/Web/Manifest/launch_handler#launch_handler_item_values
+ * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/launch_handler#launch_handler_item_values
  */
 export type LaunchHandlerClientMode = 'auto' | 'focus-existing' | 'navigate-existing' | 'navigate-new'
 
+/**
+ * @see https://w3c.github.io/manifest/#manifest-image-resources
+ */
 export interface IconResource {
   sizes?: string
   src: string
@@ -232,11 +235,15 @@ export interface ManifestOptions {
    */
   description: string
   /**
-   *
+   * @default []
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/icons
+   * @see https://w3c.github.io/manifest/#icons-member
    */
   icons: IconResource[]
   /**
-   *
+   * @default []
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/file_handlers
+   * @see https://wicg.github.io/manifest-incubations/#file_handlers-member
    */
   file_handlers: {
     action: string
@@ -260,10 +267,14 @@ export interface ManifestOptions {
   orientation: 'any' | 'natural' | 'landscape' | 'landscape-primary' | 'landscape-secondary' | 'portrait' | 'portrait-primary' | 'portrait-secondary'
   /**
    * @default `standalone`
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/display
+   * @see https://w3c.github.io/manifest/#display-member
    */
   display: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
   /**
    * @default []
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override
+   * @see https://wicg.github.io/manifest-incubations/#display_override-member
    */
   display_override: Array<'fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay'>
   /**
@@ -307,6 +318,8 @@ export interface ManifestOptions {
   }[]
   /**
    * @default []
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts
+   * @see https://w3c.github.io/manifest/#shortcuts-member
    */
   shortcuts: {
     name: string
@@ -334,6 +347,10 @@ export interface ManifestOptions {
    * @default ''
    */
   iarc_rating_id: string
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target
+   * @see https://w3c.github.io/web-share-target/level-2/#share_target-member
+   */
   share_target: {
     action: string
     method?: 'GET' | 'POST'

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,10 @@ export interface ShareTargetFiles {
  */
 export type LaunchHandlerClientMode = 'auto' | 'focus-existing' | 'navigate-existing' | 'navigate-new'
 
+export type Display = 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
+export type DisplayOverride = Display | 'window-controls-overlay'
+export type IconPurpose = 'monochrome' | 'maskable' | 'any'
+
 /**
  * @see https://w3c.github.io/manifest/#manifest-image-resources
  */
@@ -218,7 +222,10 @@ export interface IconResource {
   sizes?: string
   src: string
   type?: string
-  purpose?: 'monochrome' | 'maskable' | 'any'
+  /**
+   * **NOTE**: string values for backward compatibility with the old type.
+   */
+  purpose?: string | IconPurpose | IconPurpose[]
 }
 
 export interface ManifestOptions {
@@ -270,13 +277,13 @@ export interface ManifestOptions {
    * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/display
    * @see https://w3c.github.io/manifest/#display-member
    */
-  display: 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser'
+  display: Display
   /**
    * @default []
    * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override
    * @see https://wicg.github.io/manifest-incubations/#display_override-member
    */
-  display_override: Array<'fullscreen' | 'standalone' | 'minimal-ui' | 'browser' | 'window-controls-overlay'>
+  display_override: DisplayOverride[]
   /**
    * @default `#ffffff`
    */
@@ -330,6 +337,7 @@ export interface ManifestOptions {
   }[]
   /**
    * @default []
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots
    */
   screenshots: {
     src: string
@@ -363,23 +371,23 @@ export interface ManifestOptions {
     }
   }
   /**
-   * https://github.com/WICG/pwa-url-handler/blob/main/handle_links/explainer.md#handle_links-manifest-member
+   * @see https://github.com/WICG/pwa-url-handler/blob/main/handle_links/explainer.md#handle_links-manifest-member
    */
   handle_links?: 'auto' | 'preferred' | 'not-preferred'
   /**
-   * https://developer.mozilla.org/en-US/docs/Web/Manifest/launch_handler#launch_handler_item_values
+   * @see https://developer.mozilla.org/en-US/docs/Web/Manifest/launch_handler#launch_handler_item_values
    */
   launch_handler?: {
     client_mode: LaunchHandlerClientMode | LaunchHandlerClientMode[]
   }
   /**
-   * https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/sidebar#enable-sidebar-support-in-your-pwa
+   * @see https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/sidebar#enable-sidebar-support-in-your-pwa
    */
   edge_side_panel?: {
     preferred_width?: number
   }
   /**
-   * https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md
+   * @see https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md
    * @default []
    */
   scope_extensions: {
@@ -434,7 +442,7 @@ export interface VitePluginPWAAPI {
    */
   pwaInDevEnvironment: boolean
   /**
-   * Returns the PWA webmanifest url for the manifest link:
+   * Returns the PWA web manifest url for the manifest link:
    * <link rel="manifest" href="<webManifestUrl>" />
    *
    * Will also return if the manifest will require credentials:

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,7 +236,10 @@ export interface ManifestOptions {
   /**
    *
    */
-  file_handlers: Record<string, any>[]
+  file_handlers: {
+    action: string
+    accept: Record<string, string[]>
+  }[]
   /**
    * @default `routerBase + '?standalone=true'`
    */


### PR DESCRIPTION
Some updates to `manifest` option

1. `icons` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/icons

    https://w3c.github.io/manifest/#icons-member

    https://w3c.github.io/manifest/#manifest-image-resources

2. `display` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/display

    https://w3c.github.io/manifest/#display-member

3. `display_override` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override

    https://wicg.github.io/manifest-incubations/#display_override-member

4. `file_handlers` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/file_handlers

    https://wicg.github.io/manifest-incubations/#file_handlers-member

5. `shortcuts.icons` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts

    https://w3c.github.io/manifest/#shortcuts-member

6. `share_target` member

    https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target

    https://w3c.github.io/web-share-target/level-2/#share_target-member
