### PR TITLE
fix: remove sw cache storage entries when using self destroying option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-pwa",
   "type": "module",
   "version": "0.17.0",
-  "packageManager": "pnpm@8.10.5",
+  "packageManager": "pnpm@8.11.0",
   "description": "Zero-config PWA for Vite",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -42,16 +42,27 @@ export async function generateRegisterSW(options: ResolvedVitePWAOptions, mode: 
 export async function generateServiceWorker(options: ResolvedVitePWAOptions, viteOptions: ResolvedConfig): Promise<BuildResult> {
   if (options.selfDestroying) {
     const selfDestroyingSW = `
-self.addEventListener('install', function(e) {
+self.addEventListener('install', (e) => {
   self.skipWaiting();
 });
-self.addEventListener('activate', function(e) {
+self.addEventListener('activate', (e) => {
   self.registration.unregister()
-    .then(function() {
-      return self.clients.matchAll();
+    .then(() => self.clients.matchAll())
+    .then((clients) => {
+      clients.forEach((client) => {
+        if (client instanceof WindowClient)
+          client.navigate(client.url);
+      });
+      return Promise.resolve();
     })
-    .then(function(clients) {
-      clients.forEach(client => client.navigate(client.url))
+    .then(() => {
+      self.caches.keys().then((cacheNames) => {
+        Promise.all(
+          cacheNames.map((cacheName) => {
+            return self.caches.delete(cacheName);
+          }),
+        );
+      })
     });
 });
     `


### PR DESCRIPTION
This PR also includes:
- check if the client is a `WindowClient` before calling `navigate`, it can be `Push/Sync`  worker (missing `navigate` method)
- bump to pnpm 8.11.0

closes #560