### PR TITLE
Run configureStaticAssets when includeAssets option is true regardless of manifest option.

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -202,7 +202,7 @@ export async function resolveOptions(options: Partial<VitePWAOptions>, viteConfi
 
   // calculate hash only when required
   const calculateHash = !resolvedVitePWAOptions.disable
-    && resolvedVitePWAOptions.manifest
+    && (resolvedVitePWAOptions.manifest || resolvedVitePWAOptions.includeAssets)
     && (viteConfig.command === 'build' || resolvedVitePWAOptions.devOptions.enabled)
 
   if (calculateHash)


### PR DESCRIPTION
Fixes one line conditional enabling collection of static assets.

Currently `includeAssets` option has no effect unless `manifest` is also set. This makes it impossible to include additional assets while managing your own manifest file. 