### PR TITLE
fix: register client module and prompt

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -54,7 +54,7 @@ export function registerSW(options: RegisterSWOptions = {}) {
               window.location.reload()
           })
           wb.addEventListener('installed', (event) => {
-            if (!event.isUpdate) {
+            if (event.isUpdate === false) {
               onOfflineReady?.()
             }
           });
@@ -86,7 +86,7 @@ export function registerSW(options: RegisterSWOptions = {}) {
             // that will reload the page as soon as the previously waiting
             // service worker has taken control.
             wb?.addEventListener('controlling', (event) => {
-              if (event.isUpdate)
+              if (event.isUpdate === true || event.isExternal === true)
                 window.location.reload()
             })
 

--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -61,7 +61,18 @@ export function registerSW(options: RegisterSWOptions = {}) {
         }
         else {
           let onNeedRefreshCalled = false
-          const showSkipWaitingPrompt = () => {
+          const showSkipWaitingPrompt = (event?: import('workbox-window').WorkboxLifecycleWaitingEvent) => {
+            /*
+             FIX:
+             - open page in a new tab and navigate to home page
+             - add a new sw version
+             - open a new second tab and navigate to home page
+             - click reload on the first tab
+             - second tab refreshed, but the first tab doesn't (still with prompt)
+             */
+            if (event && onNeedRefreshCalled && event.isExternal)
+              window.location.reload()
+
             onNeedRefreshCalled = true
             // \`event.wasWaitingBeforeRegister\` will be false if this is
             // the first time the updated service worker is waiting.
@@ -103,8 +114,6 @@ export function registerSW(options: RegisterSWOptions = {}) {
           // Add an event listener to detect when the registered
           // service worker has installed but is waiting to activate.
           wb.addEventListener('waiting', showSkipWaitingPrompt)
-          // @ts-expect-error event listener provided by workbox-window
-          wb.addEventListener('externalwaiting', showSkipWaitingPrompt)
         }
       }
 


### PR DESCRIPTION
After some digging we finally fixed the problem with external sw and prompt:
- open page in a new tab and navigate to home page
- add a new sw version
- open a new second tab and navigate to home page
- click reload on the first tab
- second tab refreshed, but the first tab doesn't (still with prompt)

**NOTE**: this PR should be included in next `v0.18.0` minor release.