### PR TITLE
feat: move to `@vite-pwa/workbox-window`

### DIFF
--- a/examples/preact-router/package.json
+++ b/examples/preact-router/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
     "@rollup/plugin-replace": "^5.0.5",
+    "@vite-pwa/workbox-window": "^8.0.0",
     "https-localhost": "^4.7.1",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2",
@@ -61,7 +62,6 @@
     "vite-plugin-pwa": "workspace:*",
     "workbox-core": "^7.0.0",
     "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-routing": "^7.0.0"
   }
 }

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -60,6 +60,7 @@
     "@types/react-dom": "^18.2.15",
     "@types/react-router-config": "^5.0.10",
     "@types/react-router-dom": "^5.3.3",
+    "@vite-pwa/workbox-window": "^8.0.0",
     "@vitejs/plugin-react": "^4.2.0",
     "https-localhost": "^4.7.1",
     "rimraf": "^5.0.5",
@@ -68,7 +69,6 @@
     "vite-plugin-pwa": "workspace:*",
     "workbox-core": "^7.0.0",
     "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-routing": "^7.0.0"
   }
 }

--- a/examples/solid-router/package.json
+++ b/examples/solid-router/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
+    "@vite-pwa/workbox-window": "^8.0.0",
     "https-localhost": "^4.7.1",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2",
@@ -61,7 +62,6 @@
     "vite-plugin-solid": "^2.7.2",
     "workbox-core": "^7.0.0",
     "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-routing": "^7.0.0"
   }
 }

--- a/examples/svelte-routify/package.json
+++ b/examples/svelte-routify/package.json
@@ -52,6 +52,7 @@
     "@roxi/routify": "^2.18.12",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@tsconfig/svelte": "^5.0.2",
+    "@vite-pwa/workbox-window": "^8.0.0",
     "eslint": "^8.54.0",
     "eslint-plugin-svelte3": "^4.0.0",
     "https-localhost": "^4.7.1",

--- a/examples/vanilla-ts-no-ip/package.json
+++ b/examples/vanilla-ts-no-ip/package.json
@@ -14,6 +14,7 @@
     "test": "nr test-generate-sw && nr test-custom-sw"
   },
   "devDependencies": {
+    "@vite-pwa/workbox-window": "^8.0.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
@@ -22,7 +23,6 @@
     "workbox-core": "^7.0.0",
     "workbox-expiration": "^7.0.0",
     "workbox-routing": "^7.0.0",
-    "workbox-strategies": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-strategies": "^7.0.0"
   }
 }

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
+    "@vite-pwa/workbox-window": "^8.0.0",
     "@vitejs/plugin-vue": "^4.5.0",
     "@vueuse/core": "^10.6.1",
     "https-localhost": "^4.7.1",
@@ -62,7 +63,6 @@
     "vite-plugin-pwa": "workspace:*",
     "workbox-core": "^7.0.0",
     "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-routing": "^7.0.0"
   }
 }

--- a/examples/vue-router/src/ReloadPrompt.vue
+++ b/examples/vue-router/src/ReloadPrompt.vue
@@ -25,6 +25,12 @@ const {
       console.log(`SW Registered: ${r}`)
     }
   },
+  onInstalling(state) {
+    console.log(`SW Installing: ${state}`)
+  },
+  onUpdateFound(state) {
+    console.log(`SW Updating: ${state}`)
+  },
 })
 
 async function close() {

--- a/package.json
+++ b/package.json
@@ -106,14 +106,14 @@
   "peerDependencies": {
     "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
     "workbox-build": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "@vite-pwa/workbox-window": "^8.0.0"
   },
   "dependencies": {
     "debug": "^4.3.4",
     "fast-glob": "^3.3.2",
     "pretty-bytes": "^6.1.1",
     "workbox-build": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "@vite-pwa/workbox-window": "^8.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -18,9 +21,6 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1
       workbox-build:
-        specifier: ^7.0.0
-        version: 7.0.0
-      workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
     devDependencies:
@@ -167,6 +167,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.4.1)
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -189,9 +192,6 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
-      workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
 
@@ -228,6 +228,9 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.2.0(vite@5.0.0)
@@ -255,9 +258,6 @@ importers:
       workbox-routing:
         specifier: ^7.0.0
         version: 7.0.0
-      workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
 
   examples/solid-router:
     dependencies:
@@ -271,6 +271,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.4.1)
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -298,9 +301,6 @@ importers:
       workbox-routing:
         specifier: ^7.0.0
         version: 7.0.0
-      workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
 
   examples/svelte-routify:
     devDependencies:
@@ -316,6 +316,9 @@ importers:
       '@tsconfig/svelte':
         specifier: ^5.0.2
         version: 5.0.2
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       eslint:
         specifier: ^8.54.0
         version: 8.54.0
@@ -436,6 +439,9 @@ importers:
 
   examples/vanilla-ts-no-ip:
     devDependencies:
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -461,9 +467,6 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       workbox-strategies:
-        specifier: ^7.0.0
-        version: 7.0.0
-      workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
 
@@ -507,6 +510,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.4.1)
+      '@vite-pwa/workbox-window':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
         version: 4.5.0(vite@5.0.0)(vue@3.3.8)
@@ -535,9 +541,6 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
-      workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
 
@@ -4170,6 +4173,9 @@ packages:
       magic-string: 0.26.7
       vite: 3.1.0
     dev: true
+
+  /@vite-pwa/workbox-window@8.0.0:
+    resolution: {integrity: sha512-FLM90ZQTGp5u/ZobN9U7c440PwtrqThIsJwTGuJPtbQm5HqKiFKkPMpE7P1HKG4az1izTcg+e4HLpJCKOP5Usw==}
 
   /@vitejs/plugin-react@4.2.0(vite@5.0.0):
     resolution: {integrity: sha512-+MHTH/e6H12kRp5HUkzOGqPMksezRMmW+TNzlh/QXfI8rRf6l2Z2yH/v12no1UvTwhZgEDMuQ7g7rrfMseU6FQ==}
@@ -10675,6 +10681,7 @@ packages:
     dependencies:
       '@types/trusted-types': 2.0.2
       workbox-core: 7.0.0
+    dev: false
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}

--- a/src/client/build/preact.ts
+++ b/src/client/build/preact.ts
@@ -12,10 +12,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     onRegistered,
     onRegisteredSW,
     onRegisterError,
+    onInstalling,
+    onUpdateFound,
   } = options
 
   const [needRefresh, setNeedRefresh] = useState(false)
   const [offlineReady, setOfflineReady] = useState(false)
+  const [installingSW, setInstallingSW] = useState(false)
+  const [updatingSW, setUpdatingSW] = useState(false)
 
   const [updateServiceWorker] = useState(() => {
     return registerSW({
@@ -28,6 +32,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
         setNeedRefresh(true)
         onNeedRefresh?.()
       },
+      onInstalling(state, sw) {
+        setInstallingSW(state)
+        onInstalling?.(state, sw)
+      },
+      onUpdateFound(state, sw) {
+        setUpdatingSW(state)
+        onUpdateFound?.(state, sw)
+      },
       onRegistered,
       onRegisteredSW,
       onRegisterError,
@@ -37,6 +49,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   return {
     needRefresh: [needRefresh, setNeedRefresh],
     offlineReady: [offlineReady, setOfflineReady],
+    installingSW: [installingSW, setInstallingSW],
+    updatingSW: [updatingSW, setUpdatingSW],
     updateServiceWorker,
   }
 }

--- a/src/client/build/react.ts
+++ b/src/client/build/react.ts
@@ -12,10 +12,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     onRegistered,
     onRegisteredSW,
     onRegisterError,
+    onInstalling,
+    onUpdateFound,
   } = options
 
   const [needRefresh, setNeedRefresh] = useState(false)
   const [offlineReady, setOfflineReady] = useState(false)
+  const [installingSW, setInstallingSW] = useState(false)
+  const [updatingSW, setUpdatingSW] = useState(false)
 
   const [updateServiceWorker] = useState(() => {
     return registerSW({
@@ -28,6 +32,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
         setNeedRefresh(true)
         onNeedRefresh?.()
       },
+      onInstalling(state, sw) {
+        setInstallingSW(state)
+        onInstalling?.(state, sw)
+      },
+      onUpdateFound(state, sw) {
+        setUpdatingSW(state)
+        onUpdateFound?.(state, sw)
+      },
       onRegistered,
       onRegisteredSW,
       onRegisterError,
@@ -37,6 +49,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   return {
     needRefresh: [needRefresh, setNeedRefresh],
     offlineReady: [offlineReady, setOfflineReady],
+    installingSW: [installingSW, setInstallingSW],
+    updatingSW: [updatingSW, setUpdatingSW],
     updateServiceWorker,
   }
 }

--- a/src/client/build/solid.ts
+++ b/src/client/build/solid.ts
@@ -12,10 +12,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     onRegistered,
     onRegisteredSW,
     onRegisterError,
+    onInstalling,
+    onUpdateFound,
   } = options
 
   const [needRefresh, setNeedRefresh] = createSignal(false)
   const [offlineReady, setOfflineReady] = createSignal(false)
+  const [installingSW, setInstallingSW] = createSignal(false)
+  const [updatingSW, setUpdatingSW] = createSignal(false)
 
   const updateServiceWorker = registerSW({
     immediate,
@@ -27,6 +31,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
       setNeedRefresh(true)
       onNeedRefresh?.()
     },
+    onInstalling(state, sw) {
+      setInstallingSW(state)
+      onInstalling?.(state, sw)
+    },
+    onUpdateFound(state, sw) {
+      setUpdatingSW(state)
+      onUpdateFound?.(state, sw)
+    },
     onRegistered,
     onRegisteredSW,
     onRegisterError,
@@ -35,6 +47,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   return {
     needRefresh: [needRefresh, setNeedRefresh],
     offlineReady: [offlineReady, setOfflineReady],
+    installingSW: [installingSW, setInstallingSW],
+    updatingSW: [updatingSW, setUpdatingSW],
     updateServiceWorker,
   }
 }

--- a/src/client/build/svelte.ts
+++ b/src/client/build/svelte.ts
@@ -12,10 +12,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     onRegistered,
     onRegisteredSW,
     onRegisterError,
+    onInstalling,
+    onUpdateFound,
   } = options
 
   const needRefresh = writable(false)
   const offlineReady = writable(false)
+  const installingSW = writable(false)
+  const updatingSW = writable(false)
 
   const updateServiceWorker = registerSW({
     immediate,
@@ -27,6 +31,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
       needRefresh.set(true)
       onNeedRefresh?.()
     },
+    onInstalling(state, sw) {
+      installingSW.set(state)
+      onInstalling?.(state, sw)
+    },
+    onUpdateFound(state, sw) {
+      updatingSW.set(state)
+      onUpdateFound?.(state, sw)
+    },
     onRegistered,
     onRegisteredSW,
     onRegisterError,
@@ -35,6 +47,8 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   return {
     needRefresh,
     offlineReady,
+    installingSW,
+    updatingSW,
     updateServiceWorker,
   }
 }

--- a/src/client/build/vue.ts
+++ b/src/client/build/vue.ts
@@ -12,10 +12,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     onRegistered,
     onRegisteredSW,
     onRegisterError,
+    onInstalling,
+    onUpdateFound,
   } = options
 
   const needRefresh = ref(false)
   const offlineReady = ref(false)
+  const installingSW = ref(false)
+  const updatingSW = ref(false)
 
   const updateServiceWorker = registerSW({
     immediate,
@@ -27,6 +31,14 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
       offlineReady.value = true
       onOfflineReady?.()
     },
+    onInstalling(state, sw) {
+      installingSW.value = state
+      onInstalling?.(state, sw)
+    },
+    onUpdateFound(state, sw) {
+      updatingSW.value = state
+      onUpdateFound?.(state, sw)
+    },
     onRegistered,
     onRegisteredSW,
     onRegisterError,
@@ -36,5 +48,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
     updateServiceWorker,
     offlineReady,
     needRefresh,
+    installingSW,
+    updatingSW,
   }
 }

--- a/src/client/dev/preact.ts
+++ b/src/client/dev/preact.ts
@@ -6,12 +6,16 @@ export type { RegisterSWOptions }
 export function useRegisterSW(_options: RegisterSWOptions = {}) {
   const needRefresh = useState(false)
   const offlineReady = useState(false)
+  const installingSW = useState(false)
+  const updatingSW = useState(false)
 
   const updateServiceWorker = (_reloadPage?: boolean) => {}
 
   return {
     needRefresh,
     offlineReady,
+    installingSW,
+    updatingSW,
     updateServiceWorker,
   }
 }

--- a/src/client/dev/react.ts
+++ b/src/client/dev/react.ts
@@ -6,12 +6,16 @@ export type { RegisterSWOptions }
 export function useRegisterSW(_options: RegisterSWOptions = {}) {
   const needRefresh = useState(false)
   const offlineReady = useState(false)
+  const installingSW = useState(false)
+  const updatingSW = useState(false)
 
   const updateServiceWorker = (_reloadPage?: boolean) => {}
 
   return {
     needRefresh,
     offlineReady,
+    installingSW,
+    updatingSW,
     updateServiceWorker,
   }
 }

--- a/src/client/dev/solid.ts
+++ b/src/client/dev/solid.ts
@@ -6,12 +6,16 @@ export type { RegisterSWOptions }
 export function useRegisterSW(_options: RegisterSWOptions = {}) {
   const needRefresh = createSignal(false)
   const offlineReady = createSignal(false)
+  const installingSW = createSignal(false)
+  const updatingSW = createSignal(false)
 
   const updateServiceWorker = (_reloadPage?: boolean) => {}
 
   return {
     needRefresh,
     offlineReady,
+    installingSW,
+    updatingSW,
     updateServiceWorker,
   }
 }

--- a/src/client/dev/svelte.ts
+++ b/src/client/dev/svelte.ts
@@ -6,12 +6,16 @@ export type { RegisterSWOptions }
 export function useRegisterSW(_options: RegisterSWOptions = {}) {
   const needRefresh = writable(false)
   const offlineReady = writable(false)
+  const installingSW = writable(false)
+  const updatingSW = writable(false)
 
   const updateServiceWorker = (_reloadPage?: boolean) => {}
 
   return {
     needRefresh,
     offlineReady,
+    installingSW,
+    updatingSW,
     updateServiceWorker,
   }
 }

--- a/src/client/dev/vue.ts
+++ b/src/client/dev/vue.ts
@@ -6,6 +6,8 @@ export type { RegisterSWOptions }
 export function useRegisterSW(_options: RegisterSWOptions = {}) {
   const needRefresh = ref(false)
   const offlineReady = ref(false)
+  const installingSW = ref(false)
+  const updatingSW = ref(false)
 
   const updateServiceWorker = (_reloadPage?: boolean) => {}
 
@@ -13,5 +15,7 @@ export function useRegisterSW(_options: RegisterSWOptions = {}) {
     updateServiceWorker,
     offlineReady,
     needRefresh,
+    installingSW,
+    updatingSW,
   }
 }

--- a/src/client/type.d.ts
+++ b/src/client/type.d.ts
@@ -17,4 +17,22 @@ export interface RegisterSWOptions {
    */
   onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
   onRegisterError?: (error: any) => void
+  /**
+   * Called when the service worker is installing for the first time.
+   *
+   * This callback will also be called when the service worker is installed.
+   *
+   * @param state true when the service worker is installing for first time and false when installed.
+   * @param sw The service worker instance.
+   */
+  onInstalling?: (state: boolean, sw?: ServiceWorker) => void
+  /**
+   * Called when a new service worker version is found and it is installing.
+   *
+   * This callback will also be called when the service worker is installed.
+   *
+   * @param state true when the service worker is installing and false when installed.
+   * @param sw The service worker instance.
+   */
+  onUpdateFound?: (state: boolean, sw?: ServiceWorker) => void
 }

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -1,4 +1,4 @@
-import type { Plugin, UserConfig } from 'vite'
+import type { Plugin } from 'vite'
 import {
   VIRTUAL_MODULES,
   VIRTUAL_MODULES_MAP,
@@ -14,14 +14,6 @@ export function MainPlugin(ctx: PWAPluginContext, api: VitePluginPWAAPI) {
   return <Plugin>{
     name: 'vite-plugin-pwa',
     enforce: 'pre',
-    config() {
-      return <UserConfig>{
-        ssr: {
-          // TODO: remove until workbox-window support native ESM
-          noExternal: ['workbox-window'],
-        },
-      }
-    },
     async configResolved(config) {
       ctx.useImportRegister = false
       ctx.viteConfig = config

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,4 +17,22 @@ export interface RegisterSWOptions {
    */
   onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void
   onRegisterError?: (error: any) => void
+  /**
+   * Called when the service worker is installing for the first time.
+   *
+   * This callback will also be called when the service worker is installed .
+   *
+   * @param state true when the service worker is installing for first time and false when installed.
+   * @param sw The service worker instance.
+   */
+  onInstalling?: (state: boolean, sw?: ServiceWorker) => void
+  /**
+   * Called when a new service worker version is found and it is installing.
+   *
+   * This callback will also be called when the service worker is installed.
+   *
+   * @param state true when the service worker is installing and false when installed.
+   * @param sw The service worker instance.
+   */
+  onUpdateFound?: (state: boolean, sw?: ServiceWorker) => void
 }


### PR DESCRIPTION
This PR also includes `installing` event support for VanillaJS and all frameworks:
- VanillaJS: `onInstalling` and `onUpdateFound`
- Frameworks: same callbacks for VanillaJS and reactive `installingSW` and  `updatingSW`

**NOTE**: this PR should be included only in `v1.0.0` major version.

/cc @antfu I removed `ssr.noExternal` from main plugin, `@vite-pa/workbox-window` is ESM-first  with dual ESM/CJS package exports.