### PR TITLE
Add error handling to workbox import.

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -37,7 +37,14 @@ export function registerSW(options: RegisterSWOptions = {}) {
 
   async function register() {
     if ('serviceWorker' in navigator) {
-      const { Workbox } = await import('workbox-window')
+      const WorkboxWindow = await import('workbox-window').catch((e) => 
+        onRegisterError?.(e)
+      )
+      if (!WorkboxWindow) {
+        return
+      }
+
+      const { Workbox } = WorkboxWindow
       // __SW__, __SCOPE__ and __TYPE__ will be replaced by virtual module
       wb = new Workbox('__SW__', { scope: '__SCOPE__', type: '__TYPE__' })
       sendSkipWaitingMessage = async () => {

--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -37,16 +37,17 @@ export function registerSW(options: RegisterSWOptions = {}) {
 
   async function register() {
     if ('serviceWorker' in navigator) {
-      const WorkboxWindow = await import('workbox-window').catch((e) => 
+      wb = await import('workbox-window').then(({ Workbox }) => {
+        // __SW__, __SCOPE__ and __TYPE__ will be replaced by virtual module
+        return new Workbox('__SW__', { scope: '__SCOPE__', type: '__TYPE__' })
+      }).catch((e) => {
         onRegisterError?.(e)
-      )
-      if (!WorkboxWindow) {
-        return
-      }
+        return undefined
+      })
 
-      const { Workbox } = WorkboxWindow
-      // __SW__, __SCOPE__ and __TYPE__ will be replaced by virtual module
-      wb = new Workbox('__SW__', { scope: '__SCOPE__', type: '__TYPE__' })
+      if (!wb)
+        return
+
       sendSkipWaitingMessage = async () => {
         // Send a message to the waiting service worker,
         // instructing it to activate.


### PR DESCRIPTION
I've seen the the dynamic import for workbox fail on older browsers, see #645. This PR adds basic error handling to ignore the workbox setup in such situations.

Fixes #645.