### PR TITLE
feat(injectManifest): add sw build env options and allow change vite configuration

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -125,6 +125,7 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
     sourcemap = viteConfig.build.sourcemap,
     enableWorkboxModulesLogs,
     buildPlugins,
+    envOptions = {},
     ...userInjectManifest
   } = options.injectManifest || {}
   const injectManifest = Object.assign({}, defaultInjectManifest, userInjectManifest)
@@ -174,6 +175,11 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
     }
   }
 
+  const {
+    envDir = viteConfig.envDir,
+    envPrefix = viteConfig.envPrefix,
+  } = envOptions
+
   const resolvedVitePWAOptions: ResolvedVitePWAOptions = {
     base: basePath,
     mode,
@@ -212,6 +218,10 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
       minify: minifySW,
       sourcemap,
       enableWorkboxModulesLogs,
+    },
+    injectManifestEnvOptions: {
+      envDir,
+      envPrefix,
     },
     pwaAssets: resolvePWAAssetsOptions(pwaAssets),
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { BuildOptions, Plugin, ResolvedConfig, UserConfig } from 'vite'
+import type { BuildOptions, InlineConfig, Plugin, ResolvedConfig, UserConfig } from 'vite'
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
 import type { OutputBundle, RollupOptions } from 'rollup'
 import type { BuiltInPreset, Preset } from '@vite-pwa/assets-generator/config'
@@ -85,6 +85,26 @@ export type CustomInjectManifestOptions = InjectManifestOptions & {
    * Since `v0.15.0` you can add custom Rollup options to build your service worker: we expose the same configuration to build a worker using Vite.
    */
   rollupOptions?: Omit<RollupOptions, 'plugins' | 'output'>
+
+  /**
+   * Environment options.
+   *
+   * @since v0.19.6
+   */
+  envOptions?: {
+    /**
+     * Configure Vite `envDir` option.
+     *
+     * @default Vite `envDir`.
+     */
+    envDir?: UserConfig['envDir']
+    /**
+     * Configure Vite `envPrefix` option.
+     *
+     * @default Vite `envPrefix`.
+     */
+    envPrefix?: UserConfig['envPrefix']
+  }
 }
 
 export interface PWAIntegration {
@@ -94,6 +114,14 @@ export interface PWAIntegration {
     viteOptions: ResolvedConfig,
     options: Partial<VitePWAOptions>,
   ) => void | Promise<void>
+  /**
+   * Allow integrations to configure Vite options for custom service worker build.
+   *
+   * @param options Vite options for custom service worker build.
+   * @see src/vite-build.ts module
+   * @since v0.19.6
+   */
+  configureCustomSWViteBuild?: (options: InlineConfig) => void | Promise<void>
 }
 
 /**
@@ -387,6 +415,10 @@ export interface ResolvedVitePWAOptions extends Required<Omit<VitePWAOptions, 'p
     minify?: BuildOptions['minify']
     sourcemap?: BuildOptions['sourcemap']
     enableWorkboxModulesLogs?: true
+  }
+  injectManifestEnvOptions: {
+    envDir: ResolvedConfig['envDir']
+    envPrefix: ResolvedConfig['envPrefix']
   }
   pwaAssets: false | ResolvedPWAAssetsOptions
 }

--- a/src/vite-build.ts
+++ b/src/vite-build.ts
@@ -33,6 +33,9 @@ export async function buildSW(
   // log sw build
   logSWViteBuild(normalizePath(relative(viteOptions.root, options.swSrc)), viteOptions, format)
 
+  // allow integrations to modify the build config
+  await options.integration?.configureCustomSWViteBuild?.(inlineConfig)
+
   await build(inlineConfig)
 
   if (format !== 'iife') {
@@ -86,13 +89,19 @@ function prepareViteBuild(
   define['process.env.NODE_ENV'] = JSON.stringify(nodeEnv)
 
   const buildPlugins = options.buildPlugins
-  const { format, plugins, rollupOptions } = options.injectManifestRollupOptions
+  const {
+    format,
+    plugins,
+    rollupOptions,
+  } = options.injectManifestRollupOptions
 
   const inlineConfig = {
     root: viteOptions.root,
     base: viteOptions.base,
     resolve: viteOptions.resolve,
     mode: viteOptions.mode,
+    envDir: options.injectManifestEnvOptions.envDir,
+    envPrefix: options.injectManifestEnvOptions.envPrefix,
     // don't copy anything from public folder
     publicDir: false,
     build: {


### PR DESCRIPTION
This PR includes:
- allow configure `envOptions`  to build the service worker 
- allow the integrations to customize the Vite build options

Check https://github.com/vite-pwa/astro/issues/42

related #689
