### PR TITLE
fix: configure favicon preset when using inlined preset

### DIFF
--- a/src/pwa-assets/config.ts
+++ b/src/pwa-assets/config.ts
@@ -75,7 +75,7 @@ export async function loadAssetsGeneratorContext(
     imageResolver: () => readFile(imageFile),
     imageName,
     preset,
-    faviconPreset: userHeadLinkOptions?.preset,
+    faviconPreset: userHeadLinkOptions?.preset ?? pwaAssets.htmlPreset ?? '2023',
     htmlLinks: { xhtml, includeId },
     basePath: pwaAssets.integration?.baseUrl || ctx.viteConfig.base || '/',
     resolveSvgName: userHeadLinkOptions?.resolveSvgName ?? (name => basename(name)),


### PR DESCRIPTION
When loading pwa assets instructions using inline preset, the favicon preset is ignored since we don't have `headLinkOptions` in the plugin configuration.

closes #698