### PR TITLE
fix(workbox)!: update workbox dependencies to 7.1.0

### DIFF
--- a/examples/assets-generator/package.json
+++ b/examples/assets-generator/package.json
@@ -25,6 +25,6 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-window": "^7.0.0"
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/preact-router/package.json
+++ b/examples/preact-router/package.json
@@ -59,9 +59,9 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-core": "^7.0.0",
-    "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-core": "^7.1.0",
+    "workbox-precaching": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -66,9 +66,9 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-core": "^7.0.0",
-    "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-core": "^7.1.0",
+    "workbox-precaching": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/solid-router/package.json
+++ b/examples/solid-router/package.json
@@ -59,9 +59,9 @@
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
     "vite-plugin-solid": "^2.7.2",
-    "workbox-core": "^7.0.0",
-    "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-core": "^7.1.0",
+    "workbox-precaching": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/svelte-routify/package.json
+++ b/examples/svelte-routify/package.json
@@ -62,9 +62,9 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-core": "^7.0.0",
-    "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0"
+    "workbox-core": "^7.1.0",
+    "workbox-precaching": "^7.1.0",
+    "workbox-routing": "^7.1.0"
   },
   "eslintConfig": {
     "root": true,

--- a/examples/vanilla-js-custom-sw/package.json
+++ b/examples/vanilla-js-custom-sw/package.json
@@ -12,11 +12,11 @@
   "devDependencies": {
     "vite": "^5.0.0",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-cacheable-response": "^7.0.0",
-    "workbox-core": "^7.0.0",
-    "workbox-expiration": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-strategies": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-cacheable-response": "^7.1.0",
+    "workbox-core": "^7.1.0",
+    "workbox-expiration": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-strategies": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/vanilla-ts-no-ip/package.json
+++ b/examples/vanilla-ts-no-ip/package.json
@@ -21,11 +21,11 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-cacheable-response": "^7.0.0",
-    "workbox-core": "^7.0.0",
-    "workbox-expiration": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-strategies": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-cacheable-response": "^7.1.0",
+    "workbox-core": "^7.1.0",
+    "workbox-expiration": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-strategies": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -61,9 +61,9 @@
     "typescript": "^5.3.3",
     "vite": "^5.0.10",
     "vite-plugin-pwa": "workspace:*",
-    "workbox-core": "^7.0.0",
-    "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-core": "^7.1.0",
+    "workbox-precaching": "^7.1.0",
+    "workbox-routing": "^7.1.0",
+    "workbox-window": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^0.2.4",
     "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
-    "workbox-build": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-build": "^7.1.0",
+    "workbox-window": "^7.1.0"
   },
   "peerDependenciesMeta": {
     "@vite-pwa/assets-generator": {
@@ -123,8 +123,8 @@
     "debug": "^4.3.4",
     "fast-glob": "^3.3.2",
     "pretty-bytes": "^6.1.1",
-    "workbox-build": "^7.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-build": "^7.1.0",
+    "workbox-window": "^7.1.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,15 +18,15 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1
       workbox-build:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0(@types/babel__core@7.20.4)
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.0.0
-        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4)
+        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))
       '@antfu/ni':
         specifier: ^0.21.9
         version: 0.21.9
@@ -47,7 +47,7 @@ importers:
         version: 18.2.21
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.11.0
-        version: 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.3.3)
+        version: 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
       '@vite-pwa/assets-generator':
         specifier: ^0.2.4
         version: 0.2.4
@@ -86,16 +86,16 @@ importers:
         version: 4.2.5
       tsup:
         specifier: ^7.3.0
-        version: 7.3.0(typescript@5.3.3)
+        version: 7.3.0(postcss@8.4.32)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.17.14)
+        version: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
       vitest:
         specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(@types/node@18.17.14)
+        version: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)
       vue:
         specifier: ^3.3.8
         version: 3.3.8(typescript@5.3.3)
@@ -117,7 +117,7 @@ importers:
         version: 9.0.13
       '@vitejs/plugin-vue':
         specifier: ^3.1.0
-        version: 3.1.0(vite@3.1.0)(vue@3.2.38)
+        version: 3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.38)
       esbuild-register:
         specifier: ^3.3.3
         version: 3.3.3(esbuild@0.19.5)
@@ -138,19 +138,19 @@ importers:
         version: 4.8.2
       unocss:
         specifier: ^0.45.18
-        version: 0.45.18(vite@3.1.0)
+        version: 0.45.18(vite@3.1.0(terser@5.15.0))
       unplugin-vue-components:
         specifier: ^0.22.4
-        version: 0.22.4(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0)(vue@3.2.38)
+        version: 0.22.4(@babel/parser@7.23.3)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))(vue@3.2.38)
       vite:
         specifier: ^3.1.0
-        version: 3.1.0
+        version: 3.1.0(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:..
       vitepress:
         specifier: 1.0.0-alpha.13
-        version: 1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0)
+        version: 1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.15.0)
       workbox-window:
         specifier: ^6.5.4
         version: 6.5.4
@@ -174,13 +174,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/preact-router:
     dependencies:
@@ -193,7 +193,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.7.0
-        version: 2.7.0(@babel/core@7.23.3)(preact@10.17.1)(vite@5.0.10)
+        version: 2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.4.1)
@@ -208,22 +208,22 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-precaching:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/react-router:
     dependencies:
@@ -238,10 +238,10 @@ importers:
         version: 6.19.0(react@18.2.0)
       react-router-config:
         specifier: ^5.1.1
-        version: 5.1.1(react-router@6.19.0)(react@18.2.0)
+        version: 5.1.1(react-router@6.19.0(react@18.2.0))(react@18.2.0)
       react-router-dom:
         specifier: ^6.19.0
-        version: 6.19.0(react-dom@18.2.0)(react@18.2.0)
+        version: 6.19.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
@@ -260,7 +260,7 @@ importers:
         version: 5.3.3
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.0.10)
+        version: 4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -272,22 +272,22 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-precaching:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/solid-router:
     dependencies:
@@ -312,25 +312,25 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.5)(vite@5.0.10)
+        version: 2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-precaching:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/svelte-routify:
     devDependencies:
@@ -342,7 +342,7 @@ importers:
         version: 2.18.12
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.0(svelte@4.2.5)(vite@5.0.10)
+        version: 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       '@tsconfig/svelte':
         specifier: ^5.0.2
         version: 5.0.2
@@ -363,43 +363,43 @@ importers:
         version: 4.2.5
       svelte-check:
         specifier: ^3.6.0
-        version: 3.6.0(@babel/core@7.21.8)(svelte@4.2.5)
+        version: 3.6.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)
       svelte-preprocess:
         specifier: ^5.1.0
-        version: 5.1.0(@babel/core@7.21.8)(svelte@4.2.5)(typescript@5.3.3)
+        version: 5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-precaching:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/sveltekit-pwa:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^4.0.0
-        version: 4.0.0(rollup@2.79.0)
+        version: 4.0.0(rollup@4.4.1)
       '@sveltejs/adapter-static':
         specifier: next
-        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589)
+        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))
       '@sveltejs/kit':
         specifier: next
-        version: 1.0.0-next.589(svelte@3.50.0)(vite@4.5.0)
+        version: 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.30.3
-        version: 5.36.2(@typescript-eslint/parser@5.36.2)(eslint@8.54.0)(typescript@4.8.2)
+        version: 5.36.2(@typescript-eslint/parser@5.36.2(eslint@8.54.0)(typescript@4.8.2))(eslint@8.54.0)(typescript@4.8.2)
       '@typescript-eslint/parser':
         specifier: ^5.30.3
         version: 5.36.2(eslint@8.54.0)(typescript@4.8.2)
@@ -426,10 +426,10 @@ importers:
         version: 3.50.0
       svelte-check:
         specifier: ^2.8.0
-        version: 2.9.0(@babel/core@7.21.8)(svelte@3.50.0)
+        version: 2.9.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)
       svelte-preprocess:
         specifier: ^4.10.7
-        version: 4.10.7(@babel/core@7.21.8)(svelte@3.50.0)(typescript@4.8.2)
+        version: 4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2)
       tslib:
         specifier: ^2.4.0
         version: 2.4.0
@@ -453,28 +453,28 @@ importers:
     devDependencies:
       vite:
         specifier: ^5.0.0
-        version: 5.0.12(@types/node@18.17.14)
+        version: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-cacheable-response:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-expiration:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-strategies:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/vanilla-ts-dev-options:
     devDependencies:
@@ -486,7 +486,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -504,28 +504,28 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-cacheable-response:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-expiration:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-strategies:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
   examples/vue-basic-cdn:
     dependencies:
@@ -538,10 +538,10 @@ importers:
         version: 5.0.5(rollup@4.4.1)
       '@vitejs/plugin-vue':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.0.10)(vue@3.3.8)
+        version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))
       '@vueuse/core':
         specifier: ^10.6.1
-        version: 10.6.1(vue@3.3.8)
+        version: 10.6.1(vue@3.3.8(typescript@5.3.3))
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -550,7 +550,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -562,17 +562,17 @@ importers:
         version: 3.3.8(typescript@5.3.3)
       vue-router:
         specifier: ^4.2.5
-        version: 4.2.5(vue@3.3.8)
+        version: 4.2.5(vue@3.3.8(typescript@5.3.3))
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.4.1)
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
-        version: 4.5.0(vite@5.0.10)(vue@3.3.8)
+        version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))
       '@vueuse/core':
         specifier: ^10.6.1
-        version: 10.6.1(vue@3.3.8)
+        version: 10.6.1(vue@3.3.8(typescript@5.3.3))
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -584,22 +584,22 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       workbox-core:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-precaching:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-routing:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
       workbox-window:
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.1.0
+        version: 7.1.0
 
 packages:
 
@@ -698,24 +698,20 @@ packages:
     peerDependencies:
       ajv: '>=8'
 
-  '@babel/code-frame@7.21.4':
-    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.22.13':
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.21.7':
-    resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
+  '@babel/code-frame@7.24.2':
+    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.22.9':
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.21.8':
-    resolution: {integrity: sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==}
+  '@babel/compat-data@7.24.4':
+    resolution: {integrity: sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.23.2':
@@ -726,8 +722,8 @@ packages:
     resolution: {integrity: sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.21.5':
-    resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
+  '@babel/core@7.24.5':
+    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.22.15':
@@ -742,8 +738,8 @@ packages:
     resolution: {integrity: sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.18.6':
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
+  '@babel/generator@7.24.5':
+    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -754,21 +750,13 @@ packages:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.21.5':
-    resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-compilation-targets@7.22.15':
     resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.19.0':
-    resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
+  '@babel/helper-compilation-targets@7.23.6':
+    resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-create-class-features-plugin@7.22.15':
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
@@ -787,44 +775,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
 
-  '@babel/helper-environment-visitor@7.21.5':
-    resolution: {integrity: sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-environment-visitor@7.22.20':
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-environment-visitor@7.22.5':
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-explode-assignable-expression@7.18.6':
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-function-name@7.21.0':
-    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-function-name@7.22.5':
-    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-function-name@7.23.0':
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-hoist-variables@7.18.6':
-    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-hoist-variables@7.22.5':
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-member-expression-to-functions@7.18.9':
-    resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.23.0':
@@ -835,16 +799,12 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.21.4':
-    resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.22.15':
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.21.5':
-    resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
+  '@babel/helper-module-imports@7.24.3':
+    resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.23.0':
@@ -859,16 +819,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.18.6':
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
+  '@babel/helper-module-transforms@7.24.5':
+    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
     engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-optimise-call-expression@7.22.5':
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.21.5':
-    resolution: {integrity: sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.22.5':
@@ -881,104 +839,78 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.18.9':
-    resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-replace-supers@7.22.20':
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-simple-access@7.21.5':
-    resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-simple-access@7.22.5':
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.18.9':
-    resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
+  '@babel/helper-simple-access@7.24.5':
+    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-split-export-declaration@7.18.6':
-    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-split-export-declaration@7.22.6':
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.19.4':
-    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.21.5':
-    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+  '@babel/helper-split-export-declaration@7.24.5':
+    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.22.5':
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.19.1':
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.22.15':
-    resolution: {integrity: sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==}
+  '@babel/helper-string-parser@7.24.1':
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.21.0':
-    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+  '@babel/helper-validator-identifier@7.24.5':
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.22.15':
     resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-wrap-function@7.19.0':
-    resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
+  '@babel/helper-validator-option@7.23.5':
+    resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.21.5':
-    resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
+  '@babel/helper-wrap-function@7.19.0':
+    resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.23.2':
     resolution: {integrity: sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/highlight@7.18.6':
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+  '@babel/helpers@7.24.5':
+    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.22.13':
     resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/highlight@7.24.5':
+    resolution: {integrity: sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.19.0':
     resolution: {integrity: sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.20.5':
-    resolution: {integrity: sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.21.8':
-    resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -997,6 +929,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.24.5':
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6':
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
@@ -1012,90 +949,105 @@ packages:
   '@babel/plugin-proposal-async-generator-functions@7.19.0':
     resolution: {integrity: sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-class-static-block@7.18.6':
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-static-block instead.
     peerDependencies:
       '@babel/core': ^7.12.0
 
   '@babel/plugin-proposal-dynamic-import@7.18.6':
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-export-namespace-from@7.18.9':
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-json-strings@7.18.6':
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-json-strings instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-logical-assignment-operators@7.18.9':
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-numeric-separator@7.18.6':
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-object-rest-spread@7.18.9':
     resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-catch-binding@7.18.6':
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-chaining@7.18.9':
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-property-in-object@7.18.6':
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-unicode-property-regex@7.18.6':
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1286,12 +1238,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.18.6':
-    resolution: {integrity: sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-modules-commonjs@7.23.0':
     resolution: {integrity: sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==}
     engines: {node: '>=6.9.0'}
@@ -1445,16 +1391,12 @@ packages:
     resolution: {integrity: sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.20.7':
-    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.22.15':
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.21.5':
-    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
+  '@babel/template@7.24.0':
+    resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.23.2':
@@ -1465,12 +1407,8 @@ packages:
     resolution: {integrity: sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.20.5':
-    resolution: {integrity: sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.21.5':
-    resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
+  '@babel/traverse@7.24.5':
+    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.22.17':
@@ -1483,6 +1421,10 @@ packages:
 
   '@babel/types@7.23.3':
     resolution: {integrity: sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.24.5':
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
     engines: {node: '>=6.9.0'}
 
   '@canvas/image-data@1.0.0':
@@ -1851,6 +1793,10 @@ packages:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/gen-mapping@0.3.5':
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/resolve-uri@3.1.0':
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
@@ -1859,8 +1805,15 @@ packages:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/source-map@0.3.2':
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+
+  '@jridgewell/source-map@0.3.6':
+    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.4.14':
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -1873,6 +1826,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.18':
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@jsdevtools/ez-spawn@3.0.4':
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
@@ -1940,11 +1896,14 @@ packages:
       '@types/babel__core':
         optional: true
 
-  '@rollup/plugin-node-resolve@11.2.1':
-    resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
-    engines: {node: '>= 10.0.0'}
+  '@rollup/plugin-node-resolve@15.2.3':
+    resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
@@ -1961,6 +1920,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-terser@0.4.4':
+    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2212,8 +2180,8 @@ packages:
   '@types/react@18.2.37':
     resolution: {integrity: sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==}
 
-  '@types/resolve@1.17.1':
-    resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
   '@types/sass@1.43.1':
     resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
@@ -2806,8 +2774,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.21.3:
-    resolution: {integrity: sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==}
+  browserslist@4.23.0:
+    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2871,11 +2839,11 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001390:
-    resolution: {integrity: sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==}
-
   caniuse-lite@1.0.30001529:
     resolution: {integrity: sha512-n2pUQYGAkrLG4QYj2desAh+NqsJpHbNmVZz87imptDdxLAtjxary7Df/psdfyDGmskJK/9Dt9cPnx5RZ3CU4Og==}
+
+  caniuse-lite@1.0.30001614:
+    resolution: {integrity: sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==}
 
   chai@4.3.10:
     resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
@@ -3008,9 +2976,6 @@ packages:
   content-type@1.0.4:
     resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
     engines: {node: '>= 0.6'}
-
-  convert-source-map@1.8.0:
-    resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3221,11 +3186,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.4.243:
-    resolution: {integrity: sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==}
-
   electron-to-chromium@1.4.513:
     resolution: {integrity: sha512-cOB0xcInjm+E5qIssHeXJ29BaUyWpMyFKT5RB3bsLENDheCja0wMkHJyiPl0NBE/VzDI7JDuNEQWhe6RitEUcw==}
+
+  electron-to-chromium@1.4.751:
+    resolution: {integrity: sha512-2DEPi++qa89SMGRhufWTiLmzqyuGmNF3SK4+PQetW1JKiZdEpF4XQonJXJCzyuYSA6mauiMhbyVhqYAP45Hvfw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3242,10 +3207,6 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
-
-  es-abstract@1.20.2:
-    resolution: {integrity: sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==}
-    engines: {node: '>= 0.4'}
 
   es-abstract@1.21.2:
     resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
@@ -3806,9 +3767,6 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
-  get-intrinsic@1.1.2:
-    resolution: {integrity: sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==}
-
   get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
 
@@ -4052,10 +4010,6 @@ packages:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
 
-  is-callable@1.2.4:
-    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
-    engines: {node: '>= 0.4'}
-
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -4169,10 +4123,6 @@ packages:
     resolution: {integrity: sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  jest-worker@26.6.2:
-    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
-    engines: {node: '>= 10.13.0'}
 
   jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
@@ -4570,8 +4520,8 @@ packages:
   node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
 
-  node-releases@2.0.6:
-    resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
+  node-releases@2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -4610,9 +4560,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-inspect@1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
 
   object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -5045,12 +4992,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  rollup-plugin-terser@7.0.2:
-    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
-    peerDependencies:
-      rollup: ^2.0.0
-
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
@@ -5062,11 +5003,6 @@ packages:
   rollup@2.79.0:
     resolution: {integrity: sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==}
     engines: {node: '>=10.0.0'}
-    hasBin: true
-
-  rollup@3.29.0:
-    resolution: {integrity: sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.4.1:
@@ -5123,11 +5059,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -5137,8 +5068,8 @@ packages:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@4.0.0:
-    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   seroval@0.12.4:
     resolution: {integrity: sha512-JIsZHp98o+okpYN8HEPyI9Blr0gxAUPIGvg3waXrEMFjPz9obiLYMz0uFiUGezKiCK8loosYbn8WsqO8WtAJUA==}
@@ -5204,6 +5135,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smob@1.5.0:
+    resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
   solid-js@1.8.5:
     resolution: {integrity: sha512-xvtJvzJzWbsn35oKFhW9kNwaxG1Z/YLMsDp4tLVcYZTMPzvzQ8vEZuyDQ6nt7xDArVgZJ7TUFrJUwrui/oq53A==}
@@ -5295,14 +5229,8 @@ packages:
     resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
     engines: {node: '>= 0.4'}
 
-  string.prototype.trimend@1.0.5:
-    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==}
-
   string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
-
-  string.prototype.trimstart@1.0.5:
-    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
 
   string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
@@ -5502,6 +5430,11 @@ packages:
 
   terser@5.15.0:
     resolution: {integrity: sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.31.0:
+    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5762,8 +5695,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  update-browserslist-db@1.0.7:
-    resolution: {integrity: sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==}
+  update-browserslist-db@1.0.13:
+    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -5821,34 +5754,6 @@ packages:
       sass:
         optional: true
       stylus:
-        optional: true
-      terser:
-        optional: true
-
-  vite@4.5.0:
-    resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
         optional: true
       terser:
         optional: true
@@ -6076,18 +5981,18 @@ packages:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
 
-  workbox-background-sync@7.0.0:
-    resolution: {integrity: sha512-S+m1+84gjdueM+jIKZ+I0Lx0BDHkk5Nu6a3kTVxP4fdj3gKouRNmhO8H290ybnJTOPfBDtTMXSQA/QLTvr7PeA==}
+  workbox-background-sync@7.1.0:
+    resolution: {integrity: sha512-rMbgrzueVWDFcEq1610YyDW71z0oAXLfdRHRQcKw4SGihkfOK0JUEvqWHFwA6rJ+6TClnMIn7KQI5PNN1XQXwQ==}
 
-  workbox-broadcast-update@7.0.0:
-    resolution: {integrity: sha512-oUuh4jzZrLySOo0tC0WoKiSg90bVAcnE98uW7F8GFiSOXnhogfNDGZelPJa+6KpGBO5+Qelv04Hqx2UD+BJqNQ==}
+  workbox-broadcast-update@7.1.0:
+    resolution: {integrity: sha512-O36hIfhjej/c5ar95pO67k1GQw0/bw5tKP7CERNgK+JdxBANQhDmIuOXZTNvwb2IHBx9hj2kxvcDyRIh5nzOgQ==}
 
-  workbox-build@7.0.0:
-    resolution: {integrity: sha512-CttE7WCYW9sZC+nUYhQg3WzzGPr4IHmrPnjKiu3AMXsiNQKx+l4hHl63WTrnicLmKEKHScWDH8xsGBdrYgtBzg==}
+  workbox-build@7.1.0:
+    resolution: {integrity: sha512-F6R94XAxjB2j4ETMkP1EXKfjECOtDmyvt0vz3BzgWJMI68TNSXIVNkgatwUKBlPGOfy9n2F/4voYRNAhEvPJNg==}
     engines: {node: '>=16.0.0'}
 
-  workbox-cacheable-response@7.0.0:
-    resolution: {integrity: sha512-0lrtyGHn/LH8kKAJVOQfSu3/80WDc9Ma8ng0p2i/5HuUndGttH+mGMSvOskjOdFImLs2XZIimErp7tSOPmu/6g==}
+  workbox-cacheable-response@7.1.0:
+    resolution: {integrity: sha512-iwsLBll8Hvua3xCuBB9h92+/e0wdsmSVgR2ZlvcfjepZWwhd3osumQB3x9o7flj+FehtWM2VHbZn8UJeBXXo6Q==}
 
   workbox-core@6.5.4:
     resolution: {integrity: sha512-OXYb+m9wZm8GrORlV2vBbE5EC1FKu71GGp0H4rjmxmF4/HLbMCoTFws87M3dFwgpmg0v00K++PImpNQ6J5NQ6Q==}
@@ -6095,41 +6000,53 @@ packages:
   workbox-core@7.0.0:
     resolution: {integrity: sha512-81JkAAZtfVP8darBpfRTovHg8DGAVrKFgHpOArZbdFd78VqHr5Iw65f2guwjE2NlCFbPFDoez3D3/6ZvhI/rwQ==}
 
-  workbox-expiration@7.0.0:
-    resolution: {integrity: sha512-MLK+fogW+pC3IWU9SFE+FRStvDVutwJMR5if1g7oBJx3qwmO69BNoJQVaMXq41R0gg3MzxVfwOGKx3i9P6sOLQ==}
+  workbox-core@7.1.0:
+    resolution: {integrity: sha512-5KB4KOY8rtL31nEF7BfvU7FMzKT4B5TkbYa2tzkS+Peqj0gayMT9SytSFtNzlrvMaWgv6y/yvP9C0IbpFjV30Q==}
 
-  workbox-google-analytics@7.0.0:
-    resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+  workbox-expiration@7.1.0:
+    resolution: {integrity: sha512-m5DcMY+A63rJlPTbbBNtpJ20i3enkyOtSgYfv/l8h+D6YbbNiA0zKEkCUaMsdDlxggla1oOfRkyqTvl5Ni5KQQ==}
 
-  workbox-navigation-preload@7.0.0:
-    resolution: {integrity: sha512-juWCSrxo/fiMz3RsvDspeSLGmbgC0U9tKqcUPZBCf35s64wlaLXyn2KdHHXVQrb2cqF7I0Hc9siQalainmnXJA==}
+  workbox-google-analytics@7.1.0:
+    resolution: {integrity: sha512-FvE53kBQHfVTcZyczeBVRexhh7JTkyQ8HAvbVY6mXd2n2A7Oyz/9fIwnY406ZcDhvE4NFfKGjW56N4gBiqkrew==}
+
+  workbox-navigation-preload@7.1.0:
+    resolution: {integrity: sha512-4wyAbo0vNI/X0uWNJhCMKxnPanNyhybsReMGN9QUpaePLTiDpKxPqFxl4oUmBNddPwIXug01eTSLVIFXimRG/A==}
 
   workbox-precaching@7.0.0:
     resolution: {integrity: sha512-EC0vol623LJqTJo1mkhD9DZmMP604vHqni3EohhQVwhJlTgyKyOkMrZNy5/QHfOby+39xqC01gv4LjOm4HSfnA==}
 
-  workbox-range-requests@7.0.0:
-    resolution: {integrity: sha512-SxAzoVl9j/zRU9OT5+IQs7pbJBOUOlriB8Gn9YMvi38BNZRbM+RvkujHMo8FOe9IWrqqwYgDFBfv6sk76I1yaQ==}
+  workbox-precaching@7.1.0:
+    resolution: {integrity: sha512-LyxzQts+UEpgtmfnolo0hHdNjoB7EoRWcF7EDslt+lQGd0lW4iTvvSe3v5JiIckQSB5KTW5xiCqjFviRKPj1zA==}
 
-  workbox-recipes@7.0.0:
-    resolution: {integrity: sha512-DntcK9wuG3rYQOONWC0PejxYYIDHyWWZB/ueTbOUDQgefaeIj1kJ7pdP3LZV2lfrj8XXXBWt+JDRSw1lLLOnww==}
+  workbox-range-requests@7.1.0:
+    resolution: {integrity: sha512-m7+O4EHolNs5yb/79CrnwPR/g/PRzMFYEdo01LqwixVnc/sbzNSvKz0d04OE3aMRel1CwAAZQheRsqGDwATgPQ==}
+
+  workbox-recipes@7.1.0:
+    resolution: {integrity: sha512-NRrk4ycFN9BHXJB6WrKiRX3W3w75YNrNrzSX9cEZgFB5ubeGoO8s/SDmOYVrFYp9HMw6sh1Pm3eAY/1gVS8YLg==}
 
   workbox-routing@7.0.0:
     resolution: {integrity: sha512-8YxLr3xvqidnbVeGyRGkaV4YdlKkn5qZ1LfEePW3dq+ydE73hUUJJuLmGEykW3fMX8x8mNdL0XrWgotcuZjIvA==}
 
+  workbox-routing@7.1.0:
+    resolution: {integrity: sha512-oOYk+kLriUY2QyHkIilxUlVcFqwduLJB7oRZIENbqPGeBP/3TWHYNNdmGNhz1dvKuw7aqvJ7CQxn27/jprlTdg==}
+
   workbox-strategies@7.0.0:
     resolution: {integrity: sha512-dg3qJU7tR/Gcd/XXOOo7x9QoCI9nk74JopaJaYAQ+ugLi57gPsXycVdBnYbayVj34m6Y8ppPwIuecrzkpBVwbA==}
 
-  workbox-streams@7.0.0:
-    resolution: {integrity: sha512-moVsh+5to//l6IERWceYKGiftc+prNnqOp2sgALJJFbnNVpTXzKISlTIsrWY+ogMqt+x1oMazIdHj25kBSq/HQ==}
+  workbox-strategies@7.1.0:
+    resolution: {integrity: sha512-/UracPiGhUNehGjRm/tLUQ+9PtWmCbRufWtV0tNrALuf+HZ4F7cmObSEK+E4/Bx1p8Syx2tM+pkIrvtyetdlew==}
 
-  workbox-sw@7.0.0:
-    resolution: {integrity: sha512-SWfEouQfjRiZ7GNABzHUKUyj8pCoe+RwjfOIajcx6J5mtgKkN+t8UToHnpaJL5UVVOf5YhJh+OHhbVNIHe+LVA==}
+  workbox-streams@7.1.0:
+    resolution: {integrity: sha512-WyHAVxRXBMfysM8ORwiZnI98wvGWTVAq/lOyBjf00pXFvG0mNaVz4Ji+u+fKa/mf1i2SnTfikoYKto4ihHeS6w==}
+
+  workbox-sw@7.1.0:
+    resolution: {integrity: sha512-Hml/9+/njUXBglv3dtZ9WBKHI235AQJyLBV1G7EFmh4/mUdSQuXui80RtjDeVRrXnm/6QWgRUEHG3/YBVbxtsA==}
 
   workbox-window@6.5.4:
     resolution: {integrity: sha512-HnLZJDwYBE+hpG25AQBO8RUWBJRaCsI9ksQJEp3aCOFCaG5kqaToAYXFRAHxzRluM2cQbGzdQF5rjKPWPA1fug==}
 
-  workbox-window@7.0.0:
-    resolution: {integrity: sha512-j7P/bsAWE/a7sxqTzXo3P2ALb1reTfZdvVp6OJ/uLr/C2kZAMvjeWGm8V4htQhor7DOvYg0sSbFN2+flT5U0qA==}
+  workbox-window@7.1.0:
+    resolution: {integrity: sha512-ZHeROyqR+AS5UPzholQRDttLFqGMwP0Np8MKWAdyxsDETxq3qOAyXvqessc3GniohG6e0mAqSQyKOHmT8zPF7g==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -6286,29 +6203,29 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
 
-  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4)':
+  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))':
     dependencies:
       '@antfu/eslint-define-config': 1.23.0-2
       '@eslint-types/jsdoc': 46.8.2-1
       '@eslint-types/typescript-eslint': 6.11.0
       '@eslint-types/unicorn': 49.0.0
       '@stylistic/eslint-plugin': 1.4.0(eslint@8.54.0)(typescript@5.3.3)
-      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
       eslint-config-flat-gitignore: 0.1.1
       eslint-plugin-antfu: 1.0.10(eslint@8.54.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.54.0)
-      eslint-plugin-i: 2.29.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)
+      eslint-plugin-i: 2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)
       eslint-plugin-jsdoc: 46.9.0(eslint@8.54.0)
       eslint-plugin-jsonc: 2.10.0(eslint@8.54.0)
       eslint-plugin-markdown: 3.0.1(eslint@8.54.0)
       eslint-plugin-n: 16.3.1(eslint@8.54.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-perfectionist: 2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2)
+      eslint-plugin-perfectionist: 2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2(eslint@8.54.0))
       eslint-plugin-unicorn: 49.0.0(eslint@8.54.0)
-      eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0)(eslint@8.54.0)
-      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0)(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4)
+      eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)
+      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))
       eslint-plugin-vue: 9.18.1(eslint@8.54.0)
       eslint-plugin-yml: 1.10.0(eslint@8.54.0)
       execa: 8.0.1
@@ -6351,38 +6268,19 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@babel/code-frame@7.21.4':
-    dependencies:
-      '@babel/highlight': 7.18.6
-
   '@babel/code-frame@7.22.13':
     dependencies:
       '@babel/highlight': 7.22.13
       chalk: 2.4.2
 
-  '@babel/compat-data@7.21.7': {}
+  '@babel/code-frame@7.24.2':
+    dependencies:
+      '@babel/highlight': 7.24.5
+      picocolors: 1.0.0
 
   '@babel/compat-data@7.22.9': {}
 
-  '@babel/core@7.21.8':
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helpers': 7.21.5
-      '@babel/parser': 7.21.8
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
-      convert-source-map: 1.8.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
+  '@babel/compat-data@7.24.4': {}
 
   '@babel/core@7.23.2':
     dependencies:
@@ -6424,23 +6322,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.21.5':
+  '@babel/core@7.24.5':
     dependencies:
-      '@babel/types': 7.21.5
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.18
-      jsesc: 2.5.2
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
+      '@babel/helpers': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/generator@7.22.15':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
 
   '@babel/generator@7.23.0':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.3
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
@@ -6452,27 +6363,21 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
 
-  '@babel/helper-annotate-as-pure@7.18.6':
+  '@babel/generator@7.24.5':
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.24.5
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.18.9':
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.21.5
-
-  '@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.8)':
-    dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.8
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.3
-      lru-cache: 5.1.1
-      semver: 6.3.1
+      '@babel/types': 7.23.3
 
   '@babel/helper-compilation-targets@7.22.15':
     dependencies:
@@ -6482,25 +6387,20 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.21.8)':
+  '@babel/helper-compilation-targets@7.23.6':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/compat-data': 7.24.4
+      '@babel/helper-validator-option': 7.23.5
+      browserslist: 4.23.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
 
   '@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
@@ -6508,17 +6408,30 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.21.8)':
+  '@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.24.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+
+  '@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.1.0
 
-  '@babel/helper-define-polyfill-provider@0.3.2(@babel/core@7.21.8)':
+  '@babel/helper-define-polyfill-provider@0.3.2(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -6526,73 +6439,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-environment-visitor@7.21.5': {}
-
   '@babel/helper-environment-visitor@7.22.20': {}
-
-  '@babel/helper-environment-visitor@7.22.5': {}
 
   '@babel/helper-explode-assignable-expression@7.18.6':
     dependencies:
-      '@babel/types': 7.21.5
-
-  '@babel/helper-function-name@7.21.0':
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.21.5
-
-  '@babel/helper-function-name@7.22.5':
-    dependencies:
-      '@babel/template': 7.22.15
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
-      '@babel/template': 7.22.15
-      '@babel/types': 7.23.0
-
-  '@babel/helper-hoist-variables@7.18.6':
-    dependencies:
-      '@babel/types': 7.21.5
+      '@babel/template': 7.24.0
+      '@babel/types': 7.24.5
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.23.0
-
-  '@babel/helper-member-expression-to-functions@7.18.9':
-    dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.24.5
 
   '@babel/helper-member-expression-to-functions@7.23.0':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.3
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.22.17
-
-  '@babel/helper-module-imports@7.21.4':
-    dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.23.3
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.3
 
-  '@babel/helper-module-transforms@7.21.5':
+  '@babel/helper-module-imports@7.24.3':
     dependencies:
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-simple-access': 7.21.5
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/types': 7.24.5
 
   '@babel/helper-module-transforms@7.23.0(@babel/core@7.23.2)':
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+
+  '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
@@ -6610,35 +6497,37 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
 
-  '@babel/helper-optimise-call-expression@7.18.6':
+  '@babel/helper-module-transforms@7.23.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+
+  '@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.24.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/helper-validator-identifier': 7.24.5
 
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
-      '@babel/types': 7.22.17
-
-  '@babel/helper-plugin-utils@7.21.5': {}
+      '@babel/types': 7.23.3
 
   '@babel/helper-plugin-utils@7.22.5': {}
 
-  '@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.21.8)':
+  '@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-replace-supers@7.18.9':
-    dependencies:
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
+      '@babel/types': 7.23.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6649,262 +6538,250 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
 
-  '@babel/helper-simple-access@7.21.5':
+  '@babel/helper-replace-supers@7.22.20(@babel/core@7.24.5)':
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
 
   '@babel/helper-simple-access@7.22.5':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.3
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.18.9':
+  '@babel/helper-simple-access@7.24.5':
     dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.24.5
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
-      '@babel/types': 7.22.17
-
-  '@babel/helper-split-export-declaration@7.18.6':
-    dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.23.3
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
-  '@babel/helper-string-parser@7.19.4': {}
-
-  '@babel/helper-string-parser@7.21.5': {}
+  '@babel/helper-split-export-declaration@7.24.5':
+    dependencies:
+      '@babel/types': 7.24.5
 
   '@babel/helper-string-parser@7.22.5': {}
 
-  '@babel/helper-validator-identifier@7.19.1': {}
-
-  '@babel/helper-validator-identifier@7.22.15': {}
+  '@babel/helper-string-parser@7.24.1': {}
 
   '@babel/helper-validator-identifier@7.22.20': {}
 
-  '@babel/helper-validator-option@7.21.0': {}
+  '@babel/helper-validator-identifier@7.24.5': {}
 
   '@babel/helper-validator-option@7.22.15': {}
 
+  '@babel/helper-validator-option@7.23.5': {}
+
   '@babel/helper-wrap-function@7.19.0':
     dependencies:
-      '@babel/helper-function-name': 7.21.0
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helpers@7.21.5':
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
+      '@babel/helper-function-name': 7.23.0
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.3
+      '@babel/types': 7.23.3
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.23.2':
     dependencies:
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.2
-      '@babel/types': 7.23.0
+      '@babel/traverse': 7.23.3
+      '@babel/types': 7.23.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/highlight@7.18.6':
+  '@babel/helpers@7.24.5':
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/highlight@7.22.13':
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  '@babel/highlight@7.24.5':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.24.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+
   '@babel/parser@7.19.0':
     dependencies:
-      '@babel/types': 7.20.5
-
-  '@babel/parser@7.20.5':
-    dependencies:
-      '@babel/types': 7.20.5
-
-  '@babel/parser@7.21.8':
-    dependencies:
-      '@babel/types': 7.21.5
+      '@babel/types': 7.23.3
 
   '@babel/parser@7.22.16':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
   '@babel/parser@7.23.0':
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.3
 
   '@babel/parser@7.23.3':
     dependencies:
       '@babel/types': 7.23.3
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.8)':
+  '@babel/parser@7.24.5':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/types': 7.24.5
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-proposal-async-generator-functions@7.19.0(@babel/core@7.21.8)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.24.5)
+
+  '@babel/plugin-proposal-async-generator-functions@7.19.0(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.8)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-logical-assignment-operators@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-logical-assignment-operators@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.21.8)
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.8)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
 
-  '@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-import-assertions@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-import-assertions@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.23.2)':
     dependencies:
@@ -6916,222 +6793,204 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.23.3)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.21.8)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.21.8)':
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-block-scoping@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-block-scoping@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-classes@7.19.0(@babel/core@7.21.8)':
+  '@babel/plugin-transform-classes@7.19.0(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.18.9
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.24.5)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-destructuring@7.18.13(@babel/core@7.21.8)':
+  '@babel/plugin-transform-destructuring@7.18.13(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
+      '@babel/core': 7.24.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-for-of@7.18.8(@babel/core@7.21.8)':
+  '@babel/plugin-transform-for-of@7.18.8(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-function-name@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-literals@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-modules-amd@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-modules-amd@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.18.6(@babel/core@7.21.8)':
-    dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-simple-access': 7.21.5
-      babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
-  '@babel/plugin-transform-modules-systemjs@7.19.0(@babel/core@7.21.8)':
+  '@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+
+  '@babel/plugin-transform-modules-systemjs@7.19.0(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.19.0(@babel/core@7.21.8)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.19.0(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-new-target@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-new-target@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-object-super@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.18.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-parameters@7.18.8(@babel/core@7.21.8)':
+  '@babel/plugin-transform-parameters@7.18.8(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.3)':
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.2)':
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.3)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -7143,51 +7002,51 @@ snapshots:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.3)':
+  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2)':
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.3)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@babel/types': 7.23.0
 
-  '@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.0
 
-  '@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-spread@7.19.0(@babel/core@7.21.8)':
+  '@babel/plugin-transform-spread@7.19.0(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.21.8)':
+  '@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-typescript@7.22.15(@babel/core@7.23.2)':
     dependencies:
@@ -7197,105 +7056,105 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.2)
 
-  '@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.21.8)':
+  '@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.21.8)':
+  '@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/preset-env@7.19.0(@babel/core@7.21.8)':
+  '@babel/preset-env@7.19.0(@babel/core@7.24.5)':
     dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-proposal-async-generator-functions': 7.19.0(@babel/core@7.21.8)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-class-static-block': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-import-assertions': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-block-scoping': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-classes': 7.19.0(@babel/core@7.21.8)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-destructuring': 7.18.13(@babel/core@7.21.8)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-amd': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-systemjs': 7.19.0(@babel/core@7.21.8)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.0(@babel/core@7.21.8)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.21.8)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-regenerator': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.21.8)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.21.8)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.21.8)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/preset-modules': 0.1.5(@babel/core@7.21.8)
-      '@babel/types': 7.21.5
-      babel-plugin-polyfill-corejs2: 0.3.2(@babel/core@7.21.8)
-      babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.21.8)
-      babel-plugin-polyfill-regenerator: 0.4.0(@babel/core@7.21.8)
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.15
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-proposal-async-generator-functions': 7.19.0(@babel/core@7.24.5)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-class-static-block': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-assertions': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoping': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-classes': 7.19.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-destructuring': 7.18.13(@babel/core@7.24.5)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-amd': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-systemjs': 7.19.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-regenerator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/preset-modules': 0.1.5(@babel/core@7.24.5)
+      '@babel/types': 7.23.3
+      babel-plugin-polyfill-corejs2: 0.3.2(@babel/core@7.24.5)
+      babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.24.5)
+      babel-plugin-polyfill-regenerator: 0.4.0(@babel/core@7.24.5)
       core-js-compat: 3.25.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.5(@babel/core@7.21.8)':
+  '@babel/preset-modules@0.1.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/types': 7.21.5
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/types': 7.23.3
       esutils: 2.0.3
 
   '@babel/preset-typescript@7.23.2(@babel/core@7.23.2)':
@@ -7311,43 +7170,28 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.13.9
 
-  '@babel/template@7.20.7':
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.21.5
-
   '@babel/template@7.22.15':
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.23.3
+      '@babel/types': 7.23.3
 
-  '@babel/traverse@7.21.5':
+  '@babel/template@7.24.0':
     dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.21.5
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/code-frame': 7.24.2
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
 
   '@babel/traverse@7.23.2':
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.23.0
+      '@babel/generator': 7.23.3
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.23.0
+      '@babel/parser': 7.23.3
+      '@babel/types': 7.23.3
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -7368,22 +7212,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.20.5':
+  '@babel/traverse@7.24.5':
     dependencies:
-      '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.21.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.22.17':
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
   '@babel/types@7.23.0':
@@ -7398,13 +7245,19 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
+  '@babel/types@7.24.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
+      to-fast-properties: 2.0.0
+
   '@canvas/image-data@1.0.0': {}
 
   '@docsearch/css@3.2.1': {}
 
-  '@docsearch/js@3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0)':
+  '@docsearch/js@3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docsearch/react': 3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0)
+      '@docsearch/react': 3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       preact: 10.19.2
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -7412,14 +7265,16 @@ snapshots:
       - react
       - react-dom
 
-  '@docsearch/react@3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0)':
+  '@docsearch/react@3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.7.1
       '@algolia/autocomplete-preset-algolia': 1.7.1(@algolia/client-search@4.14.2)(algoliasearch@4.14.2)
       '@docsearch/css': 3.2.1
-      '@types/react': 18.2.21
       algoliasearch: 4.14.2
+    optionalDependencies:
+      '@types/react': 18.2.37
       react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
 
@@ -7657,14 +7512,28 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
 
+  '@jridgewell/gen-mapping@0.3.5':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/resolve-uri@3.1.0': {}
 
   '@jridgewell/set-array@1.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.2':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
+    optional: true
+
+  '@jridgewell/source-map@0.3.6':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.4.14': {}
 
@@ -7679,6 +7548,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   '@jsdevtools/ez-spawn@3.0.4':
     dependencies:
@@ -7708,18 +7582,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.21': {}
 
-  '@preact/preset-vite@2.7.0(@babel/core@7.23.3)(preact@10.17.1)(vite@5.0.10)':
+  '@preact/preset-vite@2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.3)
-      '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.2)
+      '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.3)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.2)
       debug: 4.3.4
       kolorist: 1.8.0
       resolve: 1.22.8
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -7732,7 +7606,7 @@ snapshots:
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.1(preact@10.17.1)(vite@5.0.10)':
+  '@prefresh/vite@2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
       '@babel/core': 7.23.2
       '@prefresh/babel-plugin': 0.5.0
@@ -7740,27 +7614,30 @@ snapshots:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.17.1
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
   '@remix-run/router@1.12.0': {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.21.8)(rollup@2.79.0)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.24.5)(@types/babel__core@7.20.4)(rollup@2.79.0)':
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/core': 7.24.5
+      '@babel/helper-module-imports': 7.22.15
       '@rollup/pluginutils': 3.1.0(rollup@2.79.0)
       rollup: 2.79.0
+    optionalDependencies:
+      '@types/babel__core': 7.20.4
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@2.79.0)':
+  '@rollup/plugin-node-resolve@15.2.3(rollup@2.79.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.79.0)
-      '@types/resolve': 1.17.1
-      builtin-modules: 3.3.0
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.0)
+      '@types/resolve': 1.20.2
       deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 2.79.0
 
   '@rollup/plugin-replace@2.4.2(rollup@2.79.0)':
@@ -7769,17 +7646,26 @@ snapshots:
       magic-string: 0.25.9
       rollup: 2.79.0
 
-  '@rollup/plugin-replace@4.0.0(rollup@2.79.0)':
+  '@rollup/plugin-replace@4.0.0(rollup@4.4.1)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.79.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.4.1)
       magic-string: 0.25.9
-      rollup: 2.79.0
+      rollup: 4.4.1
 
   '@rollup/plugin-replace@5.0.5(rollup@4.4.1)':
     dependencies:
       '@rollup/pluginutils': 5.0.2(rollup@4.4.1)
       magic-string: 0.30.3
+    optionalDependencies:
       rollup: 4.4.1
+
+  '@rollup/plugin-terser@0.4.4(rollup@2.79.0)':
+    dependencies:
+      serialize-javascript: 6.0.2
+      smob: 1.5.0
+      terser: 5.31.0
+    optionalDependencies:
+      rollup: 2.79.0
 
   '@rollup/pluginutils@3.1.0(rollup@2.79.0)':
     dependencies:
@@ -7788,16 +7674,32 @@ snapshots:
       picomatch: 2.3.1
       rollup: 2.79.0
 
+  '@rollup/pluginutils@3.1.0(rollup@4.4.1)':
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 4.4.1
+
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+
+  '@rollup/pluginutils@5.0.2(rollup@2.79.0)':
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 2.79.0
 
   '@rollup/pluginutils@5.0.2(rollup@4.4.1)':
     dependencies:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 4.4.1
 
   '@rollup/rollup-android-arm-eabi@4.4.1':
@@ -7911,13 +7813,13 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.7
 
-  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589)':
+  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))':
     dependencies:
-      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@4.5.0)
+      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
 
-  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@4.5.0)':
+  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.2.0
@@ -7931,53 +7833,53 @@ snapshots:
       svelte: 3.50.0
       tiny-glob: 0.2.9
       undici: 5.14.0
-      vite: 4.5.0(@types/node@18.17.14)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.50.0)(vite@4.5.0)':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
       debug: 4.3.4
       svelte: 3.50.0
-      vite: 4.5.0(@types/node@18.17.14)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.5)(vite@5.0.10)':
+  '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.5)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       debug: 4.3.4
       svelte: 4.2.5
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@4.5.0)':
+  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.50.0)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.3
       svelte: 3.50.0
       svelte-hmr: 0.15.3(svelte@3.50.0)
-      vite: 4.5.0(@types/node@18.17.14)
-      vitefu: 0.2.4(vite@4.5.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vitefu: 0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10)':
+  '@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.5)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.2.5
       svelte-hmr: 0.15.3(svelte@4.2.5)
-      vite: 5.0.10(@types/node@18.17.14)
-      vitefu: 0.2.5(vite@5.0.10)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vitefu: 0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8003,16 +7905,16 @@ snapshots:
 
   '@types/babel__generator@7.6.4':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.22.16
-      '@babel/types': 7.22.17
+      '@babel/parser': 7.23.3
+      '@babel/types': 7.23.3
 
   '@types/babel__traverse@7.20.1':
     dependencies:
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
 
   '@types/cookie@0.5.1': {}
 
@@ -8090,9 +7992,7 @@ snapshots:
       '@types/scheduler': 0.16.2
       csstype: 3.1.2
 
-  '@types/resolve@1.17.1':
-    dependencies:
-      '@types/node': 18.17.14
+  '@types/resolve@1.20.2': {}
 
   '@types/sass@1.43.1':
     dependencies:
@@ -8112,7 +8012,7 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@5.36.2(@typescript-eslint/parser@5.36.2)(eslint@8.54.0)(typescript@4.8.2)':
+  '@typescript-eslint/eslint-plugin@5.36.2(@typescript-eslint/parser@5.36.2(eslint@8.54.0)(typescript@4.8.2))(eslint@8.54.0)(typescript@4.8.2)':
     dependencies:
       '@typescript-eslint/parser': 5.36.2(eslint@8.54.0)(typescript@4.8.2)
       '@typescript-eslint/scope-manager': 5.36.2
@@ -8125,11 +8025,12 @@ snapshots:
       regexpp: 3.2.0
       semver: 7.3.7
       tsutils: 3.21.0(typescript@4.8.2)
+    optionalDependencies:
       typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.8.0
       '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
@@ -8144,6 +8045,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -8155,6 +8057,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.36.2(typescript@4.8.2)
       debug: 4.3.4
       eslint: 8.54.0
+    optionalDependencies:
       typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
@@ -8167,6 +8070,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.11.0
       debug: 4.3.4
       eslint: 8.54.0
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -8188,6 +8092,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.54.0
       tsutils: 3.21.0(typescript@4.8.2)
+    optionalDependencies:
       typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
@@ -8199,6 +8104,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.54.0
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -8214,8 +8120,9 @@ snapshots:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@4.8.2)
+    optionalDependencies:
       typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
@@ -8229,6 +8136,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -8272,11 +8180,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/astro@0.45.18(vite@3.1.0)':
+  '@unocss/astro@0.45.18(vite@3.1.0(terser@5.15.0))':
     dependencies:
       '@unocss/core': 0.45.18
       '@unocss/reset': 0.45.18
-      '@unocss/vite': 0.45.18(vite@3.1.0)
+      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.15.0))
     transitivePeerDependencies:
       - vite
 
@@ -8366,7 +8274,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.45.18
 
-  '@unocss/vite@0.45.18(vite@3.1.0)':
+  '@unocss/vite@0.45.18(vite@3.1.0(terser@5.15.0))':
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@rollup/pluginutils': 4.2.1
@@ -8376,7 +8284,7 @@ snapshots:
       '@unocss/scope': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       magic-string: 0.26.7
-      vite: 3.1.0
+      vite: 3.1.0(terser@5.15.0)
 
   '@vite-pwa/assets-generator@0.2.4':
     dependencies:
@@ -8387,35 +8295,35 @@ snapshots:
       sharp-ico: 0.1.5
       unconfig: 0.3.11
 
-  '@vitejs/plugin-react@4.2.0(vite@5.0.10)':
+  '@vitejs/plugin-react@4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.3)
       '@types/babel__core': 7.20.4
       react-refresh: 0.14.0
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@3.1.0(vite@3.1.0)(vue@3.2.38)':
+  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.38)':
     dependencies:
-      vite: 3.1.0
+      vite: 3.1.0(terser@5.15.0)
       vue: 3.2.38
 
-  '@vitejs/plugin-vue@3.1.0(vite@3.1.0)(vue@3.2.45)':
+  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.45)':
     dependencies:
-      vite: 3.1.0
+      vite: 3.1.0(terser@5.15.0)
       vue: 3.2.45
 
-  '@vitejs/plugin-vue@4.3.4(vite@5.0.10)(vue@3.3.8)':
+  '@vitejs/plugin-vue@4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vue: 3.3.8(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@4.5.0(vite@5.0.10)(vue@3.3.8)':
+  '@vitejs/plugin-vue@4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.10(@types/node@18.17.14)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
       vue: 3.3.8(typescript@5.3.3)
 
   '@vitest/expect@1.0.0-beta.4':
@@ -8448,21 +8356,21 @@ snapshots:
 
   '@vue/compiler-core@3.2.38':
     dependencies:
-      '@babel/parser': 7.20.5
+      '@babel/parser': 7.23.3
       '@vue/shared': 3.2.38
       estree-walker: 2.0.2
       source-map: 0.6.1
 
   '@vue/compiler-core@3.2.45':
     dependencies:
-      '@babel/parser': 7.20.5
+      '@babel/parser': 7.23.3
       '@vue/shared': 3.2.45
       estree-walker: 2.0.2
       source-map: 0.6.1
 
   '@vue/compiler-core@3.3.8':
     dependencies:
-      '@babel/parser': 7.23.0
+      '@babel/parser': 7.23.3
       '@vue/shared': 3.3.8
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -8497,7 +8405,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.2.45':
     dependencies:
-      '@babel/parser': 7.20.5
+      '@babel/parser': 7.23.3
       '@vue/compiler-core': 3.2.45
       '@vue/compiler-dom': 3.2.45
       '@vue/compiler-ssr': 3.2.45
@@ -8542,7 +8450,7 @@ snapshots:
 
   '@vue/reactivity-transform@3.2.38':
     dependencies:
-      '@babel/parser': 7.20.5
+      '@babel/parser': 7.23.3
       '@vue/compiler-core': 3.2.38
       '@vue/shared': 3.2.38
       estree-walker: 2.0.2
@@ -8550,7 +8458,7 @@ snapshots:
 
   '@vue/reactivity-transform@3.2.45':
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.3
       '@vue/compiler-core': 3.2.45
       '@vue/shared': 3.2.45
       estree-walker: 2.0.2
@@ -8558,7 +8466,7 @@ snapshots:
 
   '@vue/reactivity-transform@3.3.8':
     dependencies:
-      '@babel/parser': 7.23.0
+      '@babel/parser': 7.23.3
       '@vue/compiler-core': 3.3.8
       '@vue/shared': 3.3.8
       estree-walker: 2.0.2
@@ -8621,7 +8529,7 @@ snapshots:
       '@vue/shared': 3.2.45
       vue: 3.2.45
 
-  '@vue/server-renderer@3.3.8(vue@3.3.8)':
+  '@vue/server-renderer@3.3.8(vue@3.3.8(typescript@5.3.3))':
     dependencies:
       '@vue/compiler-ssr': 3.3.8
       '@vue/shared': 3.3.8
@@ -8633,12 +8541,12 @@ snapshots:
 
   '@vue/shared@3.3.8': {}
 
-  '@vueuse/core@10.6.1(vue@3.3.8)':
+  '@vueuse/core@10.6.1(vue@3.3.8(typescript@5.3.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.6.1
-      '@vueuse/shared': 10.6.1(vue@3.3.8)
-      vue-demi: 0.14.6(vue@3.3.8)
+      '@vueuse/shared': 10.6.1(vue@3.3.8(typescript@5.3.3))
+      vue-demi: 0.14.6(vue@3.3.8(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -8669,9 +8577,9 @@ snapshots:
 
   '@vueuse/metadata@9.6.0': {}
 
-  '@vueuse/shared@10.6.1(vue@3.3.8)':
+  '@vueuse/shared@10.6.1(vue@3.3.8(typescript@5.3.3))':
     dependencies:
-      vue-demi: 0.14.6(vue@3.3.8)
+      vue-demi: 0.14.6(vue@3.3.8(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -8822,37 +8730,37 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.18.6
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.2)
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.3
       html-entities: 2.3.3
       validate-html-nesting: 1.2.2
 
-  babel-plugin-polyfill-corejs2@0.3.2(@babel/core@7.21.8):
+  babel-plugin-polyfill-corejs2@0.3.2(@babel/core@7.24.5):
     dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.8
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.21.8)
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.24.5)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.21.8):
+  babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.24.5)
       core-js-compat: 3.25.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.4.0(@babel/core@7.21.8):
+  babel-plugin-polyfill-regenerator@0.4.0(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.21.8
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.23.3):
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.23.2):
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.2
 
   babel-preset-solid@1.8.4(@babel/core@7.23.2):
     dependencies:
@@ -8914,12 +8822,12 @@ snapshots:
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
 
-  browserslist@4.21.3:
+  browserslist@4.23.0:
     dependencies:
-      caniuse-lite: 1.0.30001390
-      electron-to-chromium: 1.4.243
-      node-releases: 2.0.6
-      update-browserslist-db: 1.0.7(browserslist@4.21.3)
+      caniuse-lite: 1.0.30001614
+      electron-to-chromium: 1.4.751
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
   buffer-crc32@0.2.13: {}
 
@@ -8985,15 +8893,15 @@ snapshots:
   call-bind@1.0.2:
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.1
 
   call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001390: {}
-
   caniuse-lite@1.0.30001529: {}
+
+  caniuse-lite@1.0.30001614: {}
 
   chai@4.3.10:
     dependencies:
@@ -9136,10 +9044,6 @@ snapshots:
 
   content-type@1.0.4: {}
 
-  convert-source-map@1.8.0:
-    dependencies:
-      safe-buffer: 5.1.2
-
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.6: {}
@@ -9148,7 +9052,7 @@ snapshots:
 
   core-js-compat@3.25.0:
     dependencies:
-      browserslist: 4.21.3
+      browserslist: 4.21.10
       semver: 7.0.0
 
   core-util-is@1.0.3: {}
@@ -9300,9 +9204,9 @@ snapshots:
     dependencies:
       jake: 10.8.5
 
-  electron-to-chromium@1.4.243: {}
-
   electron-to-chromium@1.4.513: {}
+
+  electron-to-chromium@1.4.751: {}
 
   emoji-regex@8.0.0: {}
 
@@ -9317,32 +9221,6 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
-
-  es-abstract@1.20.2:
-    dependencies:
-      call-bind: 1.0.2
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      function.prototype.name: 1.1.5
-      get-intrinsic: 1.2.1
-      get-symbol-description: 1.0.0
-      has: 1.0.3
-      has-property-descriptors: 1.0.0
-      has-symbols: 1.0.3
-      internal-slot: 1.0.5
-      is-callable: 1.2.4
-      is-negative-zero: 2.0.2
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.2
-      is-string: 1.0.7
-      is-weakref: 1.0.2
-      object-inspect: 1.12.2
-      object-keys: 1.1.1
-      object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
-      string.prototype.trimend: 1.0.5
-      string.prototype.trimstart: 1.0.5
-      unbox-primitive: 1.0.2
 
   es-abstract@1.21.2:
     dependencies:
@@ -9389,7 +9267,7 @@ snapshots:
 
   es-to-primitive@1.2.1:
     dependencies:
-      is-callable: 1.2.4
+      is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
@@ -9566,10 +9444,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
     dependencies:
-      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -9591,13 +9470,13 @@ snapshots:
       eslint: 8.54.0
       ignore: 5.2.4
 
-  eslint-plugin-i@2.29.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0):
+  eslint-plugin-i@2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0):
     dependencies:
       debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
       get-tsconfig: 4.7.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -9655,12 +9534,13 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.1.0: {}
 
-  eslint-plugin-perfectionist@2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2):
+  eslint-plugin-perfectionist@2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2(eslint@8.54.0)):
     dependencies:
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
       minimatch: 9.0.3
       natural-compare-lite: 1.4.0
+    optionalDependencies:
       svelte: 4.2.5
       vue-eslint-parser: 9.3.2(eslint@8.54.0)
     transitivePeerDependencies:
@@ -9695,18 +9575,20 @@ snapshots:
       semver: 7.5.4
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.11.0)(eslint@8.54.0):
+  eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
       eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
 
-  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0)(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4):
+  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.54.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
-      vitest: 1.0.0-beta.4(@types/node@18.17.14)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
+      vitest: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10028,7 +9910,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.2
+      es-abstract: 1.21.2
       functions-have-names: 1.2.3
 
   functional-red-black-tree@1.0.1: {}
@@ -10040,12 +9922,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-func-name@2.0.2: {}
-
-  get-intrinsic@1.1.2:
-    dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.3
 
   get-intrinsic@1.2.1:
     dependencies:
@@ -10063,7 +9939,7 @@ snapshots:
   get-symbol-description@1.0.0:
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.1
 
   get-tsconfig@4.7.0:
     dependencies:
@@ -10170,7 +10046,7 @@ snapshots:
 
   has-property-descriptors@1.0.0:
     dependencies:
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.1
 
   has-proto@1.0.1: {}
 
@@ -10317,8 +10193,6 @@ snapshots:
     dependencies:
       builtin-modules: 3.3.0
 
-  is-callable@1.2.4: {}
-
   is-callable@1.2.7: {}
 
   is-core-module@2.11.0:
@@ -10419,12 +10293,6 @@ snapshots:
       filelist: 1.0.4
       minimatch: 3.1.2
 
-  jest-worker@26.6.2:
-    dependencies:
-      '@types/node': 18.17.14
-      merge-stream: 2.0.0
-      supports-color: 7.2.0
-
   jiti@1.18.2: {}
 
   jiti@1.21.0: {}
@@ -10442,7 +10310,7 @@ snapshots:
   jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9):
     dependencies:
       abab: 2.0.6
-      acorn: 8.10.0
+      acorn: 8.11.2
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -10493,7 +10361,7 @@ snapshots:
 
   jsonc-eslint-parser@2.4.0:
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.11.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       semver: 7.5.4
@@ -10761,7 +10629,7 @@ snapshots:
 
   node-releases@2.0.13: {}
 
-  node-releases@2.0.6: {}
+  node-releases@2.0.14: {}
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -10800,8 +10668,6 @@ snapshots:
   nwsapi@2.2.2: {}
 
   object-assign@4.1.1: {}
-
-  object-inspect@1.12.2: {}
 
   object-inspect@1.12.3: {}
 
@@ -10966,10 +10832,12 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-load-config@4.0.1:
+  postcss-load-config@4.0.1(postcss@8.4.32):
     dependencies:
       lilconfig: 2.0.6
       yaml: 2.1.1
+    optionalDependencies:
+      postcss: 8.4.32
 
   postcss-selector-parser@6.0.13:
     dependencies:
@@ -11104,13 +10972,13 @@ snapshots:
 
   react-refresh@0.14.0: {}
 
-  react-router-config@5.1.1(react-router@6.19.0)(react@18.2.0):
+  react-router-config@5.1.1(react-router@6.19.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.19.0
       react: 18.2.0
       react-router: 6.19.0(react@18.2.0)
 
-  react-router-dom@6.19.0(react-dom@18.2.0)(react@18.2.0):
+  react-router-dom@6.19.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@remix-run/router': 1.12.0
       react: 18.2.0
@@ -11238,14 +11106,6 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  rollup-plugin-terser@7.0.2(rollup@2.79.0):
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      jest-worker: 26.6.2
-      rollup: 2.79.0
-      serialize-javascript: 4.0.0
-      terser: 5.15.0
-
   rollup-pluginutils@2.8.2:
     dependencies:
       estree-walker: 0.6.1
@@ -11255,10 +11115,6 @@ snapshots:
       fsevents: 2.3.3
 
   rollup@2.79.0:
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  rollup@3.29.0:
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11325,10 +11181,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.3.8:
-    dependencies:
-      lru-cache: 6.0.0
-
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
@@ -11351,7 +11203,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@4.0.0:
+  serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
 
@@ -11402,8 +11254,8 @@ snapshots:
   side-channel@1.0.4:
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.2
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.1
+      object-inspect: 1.12.3
 
   siginfo@2.0.0: {}
 
@@ -11432,6 +11284,8 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  smob@1.5.0: {}
 
   solid-js@1.8.5:
     dependencies:
@@ -11553,19 +11407,7 @@ snapshots:
       define-properties: 1.1.4
       es-abstract: 1.21.2
 
-  string.prototype.trimend@1.0.5:
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.2
-
   string.prototype.trimend@1.0.6:
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.2
-
-  string.prototype.trimstart@1.0.5:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
@@ -11636,7 +11478,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@2.9.0(@babel/core@7.21.8)(svelte@3.50.0):
+  svelte-check@2.9.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.15
       chokidar: 3.5.3
@@ -11645,7 +11487,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.50.0
-      svelte-preprocess: 4.10.7(@babel/core@7.21.8)(svelte@3.50.0)(typescript@4.9.4)
+      svelte-preprocess: 4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -11659,7 +11501,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.6.0(@babel/core@7.21.8)(svelte@4.2.5):
+  svelte-check@3.6.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       chokidar: 3.5.3
@@ -11668,7 +11510,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.5
-      svelte-preprocess: 5.1.0(@babel/core@7.21.8)(svelte@4.2.5)(typescript@5.3.3)
+      svelte-preprocess: 5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -11689,9 +11531,8 @@ snapshots:
     dependencies:
       svelte: 4.2.5
 
-  svelte-preprocess@4.10.7(@babel/core@7.21.8)(svelte@3.50.0)(typescript@4.8.2):
+  svelte-preprocess@4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2):
     dependencies:
-      '@babel/core': 7.21.8
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
@@ -11699,11 +11540,14 @@ snapshots:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.50.0
+    optionalDependencies:
+      '@babel/core': 7.23.3
+      postcss: 8.4.32
+      postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 4.8.2
 
-  svelte-preprocess@4.10.7(@babel/core@7.21.8)(svelte@3.50.0)(typescript@4.9.4):
+  svelte-preprocess@4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4):
     dependencies:
-      '@babel/core': 7.21.8
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
@@ -11711,17 +11555,24 @@ snapshots:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.50.0
+    optionalDependencies:
+      '@babel/core': 7.23.3
+      postcss: 8.4.32
+      postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 4.9.4
 
-  svelte-preprocess@5.1.0(@babel/core@7.21.8)(svelte@4.2.5)(typescript@5.3.3):
+  svelte-preprocess@5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3):
     dependencies:
-      '@babel/core': 7.21.8
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.27.0
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.2.5
+    optionalDependencies:
+      '@babel/core': 7.23.3
+      postcss: 8.4.32
+      postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 5.3.3
 
   svelte@3.50.0: {}
@@ -11792,7 +11643,15 @@ snapshots:
   terser@5.15.0:
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.10.0
+      acorn: 8.11.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    optional: true
+
+  terser@5.31.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.11.2
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -11858,7 +11717,7 @@ snapshots:
 
   tslib@2.4.0: {}
 
-  tsup@7.3.0(typescript@5.3.3):
+  tsup@7.3.0(postcss@8.4.32)(typescript@5.3.3):
     dependencies:
       bundle-require: 4.0.1(esbuild@0.19.5)
       cac: 6.7.14
@@ -11868,12 +11727,14 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1
+      postcss-load-config: 4.0.1(postcss@8.4.32)
       resolve-from: 5.0.0
       rollup: 4.4.1
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.4.32
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -11978,9 +11839,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.45.18(vite@3.1.0):
+  unocss@0.45.18(vite@3.1.0(terser@5.15.0)):
     dependencies:
-      '@unocss/astro': 0.45.18(vite@3.1.0)
+      '@unocss/astro': 0.45.18(vite@3.1.0(terser@5.15.0))
       '@unocss/cli': 0.45.18
       '@unocss/core': 0.45.18
       '@unocss/preset-attributify': 0.45.18
@@ -11996,14 +11857,14 @@ snapshots:
       '@unocss/transformer-compile-class': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       '@unocss/transformer-variant-group': 0.45.18
-      '@unocss/vite': 0.45.18(vite@3.1.0)
+      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.15.0))
     transitivePeerDependencies:
       - supports-color
       - vite
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.22.4(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0)(vue@3.2.38):
+  unplugin-vue-components@0.22.4(@babel/parser@7.23.3)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))(vue@3.2.38):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -12014,8 +11875,10 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0)
+      unplugin: 0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))
       vue: 3.2.38
+    optionalDependencies:
+      '@babel/parser': 7.23.3
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12023,15 +11886,16 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0):
+  unplugin@0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0)):
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
-      esbuild: 0.19.5
-      rollup: 4.4.1
-      vite: 3.1.0
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.4
+    optionalDependencies:
+      esbuild: 0.19.5
+      rollup: 4.4.1
+      vite: 3.1.0(terser@5.15.0)
 
   upath@1.2.0: {}
 
@@ -12041,9 +11905,9 @@ snapshots:
       escalade: 3.1.1
       picocolors: 1.0.0
 
-  update-browserslist-db@1.0.7(browserslist@4.21.3):
+  update-browserslist-db@1.0.13(browserslist@4.23.0):
     dependencies:
-      browserslist: 4.21.3
+      browserslist: 4.23.0
       escalade: 3.1.1
       picocolors: 1.0.0
 
@@ -12073,14 +11937,14 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@1.0.0-beta.4(@types/node@18.17.14):
+  vite-node@1.0.0-beta.4(@types/node@18.17.14)(terser@5.15.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@18.17.14)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12091,7 +11955,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@2.7.2(solid-js@1.8.5)(vite@5.0.10):
+  vite-plugin-solid@2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
     dependencies:
       '@babel/core': 7.23.2
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
@@ -12100,12 +11964,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.5
       solid-refresh: 0.5.3(solid-js@1.8.5)
-      vite: 5.0.10(@types/node@18.17.14)
-      vitefu: 0.2.4(vite@5.0.10)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vitefu: 0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@3.1.0:
+  vite@3.1.0(terser@5.15.0):
     dependencies:
       esbuild: 0.15.7
       postcss: 8.4.20
@@ -12113,56 +11977,50 @@ snapshots:
       rollup: 2.78.1
     optionalDependencies:
       fsevents: 2.3.3
+      terser: 5.15.0
 
-  vite@4.5.0(@types/node@18.17.14):
+  vite@5.0.10(@types/node@18.17.14)(terser@5.15.0):
     dependencies:
-      '@types/node': 18.17.14
-      esbuild: 0.18.20
-      postcss: 8.4.32
-      rollup: 3.29.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  vite@5.0.10(@types/node@18.17.14):
-    dependencies:
-      '@types/node': 18.17.14
       esbuild: 0.19.5
       postcss: 8.4.32
       rollup: 4.4.1
     optionalDependencies:
-      fsevents: 2.3.3
-
-  vite@5.0.12(@types/node@18.17.14):
-    dependencies:
       '@types/node': 18.17.14
+      fsevents: 2.3.3
+      terser: 5.15.0
+
+  vite@5.0.12(@types/node@18.17.14)(terser@5.15.0):
+    dependencies:
       esbuild: 0.19.5
       postcss: 8.4.32
       rollup: 4.4.1
     optionalDependencies:
+      '@types/node': 18.17.14
       fsevents: 2.3.3
+      terser: 5.15.0
 
-  vitefu@0.2.4(vite@4.5.0):
-    dependencies:
-      vite: 4.5.0(@types/node@18.17.14)
+  vitefu@0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
+    optionalDependencies:
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
 
-  vitefu@0.2.4(vite@5.0.10):
-    dependencies:
-      vite: 5.0.10(@types/node@18.17.14)
+  vitefu@0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)):
+    optionalDependencies:
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
 
-  vitefu@0.2.5(vite@5.0.10):
-    dependencies:
-      vite: 5.0.10(@types/node@18.17.14)
+  vitefu@0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
+    optionalDependencies:
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
 
-  vitepress@1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0):
+  vitepress@1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.15.0):
     dependencies:
       '@docsearch/css': 3.2.1
-      '@docsearch/js': 3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.21)(react@18.2.0)
-      '@vitejs/plugin-vue': 3.1.0(vite@3.1.0)(vue@3.2.45)
+      '@docsearch/js': 3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@vitejs/plugin-vue': 3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.45)
       '@vue/devtools-api': 6.4.5
       '@vueuse/core': 9.6.0(vue@3.2.45)
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.11.1
-      vite: 3.1.0
+      vite: 3.1.0(terser@5.15.0)
       vue: 3.2.45
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -12175,9 +12033,8 @@ snapshots:
       - stylus
       - terser
 
-  vitest@1.0.0-beta.4(@types/node@18.17.14):
+  vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0):
     dependencies:
-      '@types/node': 18.17.14
       '@vitest/expect': 1.0.0-beta.4
       '@vitest/runner': 1.0.0-beta.4
       '@vitest/snapshot': 1.0.0-beta.4
@@ -12196,9 +12053,12 @@ snapshots:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.8.1
-      vite: 5.0.12(@types/node@18.17.14)
-      vite-node: 1.0.0-beta.4(@types/node@18.17.14)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vite-node: 1.0.0-beta.4(@types/node@18.17.14)(terser@5.15.0)
       why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 18.17.14
+      jsdom: 16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12220,7 +12080,7 @@ snapshots:
     dependencies:
       vue: 3.2.45
 
-  vue-demi@0.14.6(vue@3.3.8):
+  vue-demi@0.14.6(vue@3.3.8(typescript@5.3.3)):
     dependencies:
       vue: 3.3.8(typescript@5.3.3)
 
@@ -12237,7 +12097,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.2.5(vue@3.3.8):
+  vue-router@4.2.5(vue@3.3.8(typescript@5.3.3)):
     dependencies:
       '@vue/devtools-api': 6.5.0
       vue: 3.3.8(typescript@5.3.3)
@@ -12263,8 +12123,9 @@ snapshots:
       '@vue/compiler-dom': 3.3.8
       '@vue/compiler-sfc': 3.3.8
       '@vue/runtime-dom': 3.3.8
-      '@vue/server-renderer': 3.3.8(vue@3.3.8)
+      '@vue/server-renderer': 3.3.8(vue@3.3.8(typescript@5.3.3))
       '@vue/shared': 3.3.8
+    optionalDependencies:
       typescript: 5.3.3
 
   w3c-hr-time@1.0.2:
@@ -12342,24 +12203,25 @@ snapshots:
 
   word-wrap@1.2.3: {}
 
-  workbox-background-sync@7.0.0:
+  workbox-background-sync@7.1.0:
     dependencies:
       idb: 7.0.2
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
-  workbox-broadcast-update@7.0.0:
+  workbox-broadcast-update@7.1.0:
     dependencies:
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
-  workbox-build@7.0.0:
+  workbox-build@7.1.0(@types/babel__core@7.20.4):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.11.0)
-      '@babel/core': 7.21.8
-      '@babel/preset-env': 7.19.0(@babel/core@7.21.8)
+      '@babel/core': 7.24.5
+      '@babel/preset-env': 7.19.0(@babel/core@7.24.5)
       '@babel/runtime': 7.19.0
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.21.8)(rollup@2.79.0)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.0)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.24.5)(@types/babel__core@7.20.4)(rollup@2.79.0)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.0)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.0)
+      '@rollup/plugin-terser': 0.4.4(rollup@2.79.0)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.11.0
       common-tags: 1.8.2
@@ -12369,54 +12231,55 @@ snapshots:
       lodash: 4.17.21
       pretty-bytes: 5.6.0
       rollup: 2.79.0
-      rollup-plugin-terser: 7.0.2(rollup@2.79.0)
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
       tempy: 0.6.0
       upath: 1.2.0
-      workbox-background-sync: 7.0.0
-      workbox-broadcast-update: 7.0.0
-      workbox-cacheable-response: 7.0.0
-      workbox-core: 7.0.0
-      workbox-expiration: 7.0.0
-      workbox-google-analytics: 7.0.0
-      workbox-navigation-preload: 7.0.0
-      workbox-precaching: 7.0.0
-      workbox-range-requests: 7.0.0
-      workbox-recipes: 7.0.0
-      workbox-routing: 7.0.0
-      workbox-strategies: 7.0.0
-      workbox-streams: 7.0.0
-      workbox-sw: 7.0.0
-      workbox-window: 7.0.0
+      workbox-background-sync: 7.1.0
+      workbox-broadcast-update: 7.1.0
+      workbox-cacheable-response: 7.1.0
+      workbox-core: 7.1.0
+      workbox-expiration: 7.1.0
+      workbox-google-analytics: 7.1.0
+      workbox-navigation-preload: 7.1.0
+      workbox-precaching: 7.1.0
+      workbox-range-requests: 7.1.0
+      workbox-recipes: 7.1.0
+      workbox-routing: 7.1.0
+      workbox-strategies: 7.1.0
+      workbox-streams: 7.1.0
+      workbox-sw: 7.1.0
+      workbox-window: 7.1.0
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
 
-  workbox-cacheable-response@7.0.0:
+  workbox-cacheable-response@7.1.0:
     dependencies:
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
   workbox-core@6.5.4: {}
 
   workbox-core@7.0.0: {}
 
-  workbox-expiration@7.0.0:
+  workbox-core@7.1.0: {}
+
+  workbox-expiration@7.1.0:
     dependencies:
       idb: 7.0.2
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
-  workbox-google-analytics@7.0.0:
+  workbox-google-analytics@7.1.0:
     dependencies:
-      workbox-background-sync: 7.0.0
-      workbox-core: 7.0.0
-      workbox-routing: 7.0.0
-      workbox-strategies: 7.0.0
+      workbox-background-sync: 7.1.0
+      workbox-core: 7.1.0
+      workbox-routing: 7.1.0
+      workbox-strategies: 7.1.0
 
-  workbox-navigation-preload@7.0.0:
+  workbox-navigation-preload@7.1.0:
     dependencies:
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
   workbox-precaching@7.0.0:
     dependencies:
@@ -12424,43 +12287,57 @@ snapshots:
       workbox-routing: 7.0.0
       workbox-strategies: 7.0.0
 
-  workbox-range-requests@7.0.0:
+  workbox-precaching@7.1.0:
     dependencies:
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
+      workbox-routing: 7.1.0
+      workbox-strategies: 7.1.0
 
-  workbox-recipes@7.0.0:
+  workbox-range-requests@7.1.0:
     dependencies:
-      workbox-cacheable-response: 7.0.0
-      workbox-core: 7.0.0
-      workbox-expiration: 7.0.0
-      workbox-precaching: 7.0.0
-      workbox-routing: 7.0.0
-      workbox-strategies: 7.0.0
+      workbox-core: 7.1.0
+
+  workbox-recipes@7.1.0:
+    dependencies:
+      workbox-cacheable-response: 7.1.0
+      workbox-core: 7.1.0
+      workbox-expiration: 7.1.0
+      workbox-precaching: 7.1.0
+      workbox-routing: 7.1.0
+      workbox-strategies: 7.1.0
 
   workbox-routing@7.0.0:
     dependencies:
       workbox-core: 7.0.0
 
+  workbox-routing@7.1.0:
+    dependencies:
+      workbox-core: 7.1.0
+
   workbox-strategies@7.0.0:
     dependencies:
       workbox-core: 7.0.0
 
-  workbox-streams@7.0.0:
+  workbox-strategies@7.1.0:
     dependencies:
-      workbox-core: 7.0.0
-      workbox-routing: 7.0.0
+      workbox-core: 7.1.0
 
-  workbox-sw@7.0.0: {}
+  workbox-streams@7.1.0:
+    dependencies:
+      workbox-core: 7.1.0
+      workbox-routing: 7.1.0
+
+  workbox-sw@7.1.0: {}
 
   workbox-window@6.5.4:
     dependencies:
       '@types/trusted-types': 2.0.2
       workbox-core: 6.5.4
 
-  workbox-window@7.0.0:
+  workbox-window@7.1.0:
     dependencies:
       '@types/trusted-types': 2.0.2
-      workbox-core: 7.0.0
+      workbox-core: 7.1.0
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -12477,7 +12354,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.9(bufferutil@4.0.6)(utf-8-validate@5.0.9):
-    dependencies:
+    optionalDependencies:
       bufferutil: 4.0.6
       utf-8-validate: 5.0.9
 


### PR DESCRIPTION
`workbox-google-analytics` has been deprecated, it is not compatible with newer Google Analytics v4: https://developer.chrome.com/docs/workbox/modules/workbox-google-analytics/

```shell
pnpm ls --depth Infinity @rollup/plugin-node-resolve
Legend: production dependency, optional only, dev only

vite-plugin-pwa@0.19.8 D:\work\pwa\vite-plugin-pwa-main

dependencies:
workbox-build 7.1.0
└── @rollup/plugin-node-resolve 15.2.3
```

supersedes #592