### PR TITLE
fix: ensure base path ends with forward slash

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,15 @@ export function slash(str: string) {
 export function resolveBasePath(base: string) {
   if (isAbsolute(base))
     return base
-  return (!base.startsWith('/') && !base.startsWith('./'))
-    ? `/${base}`
-    : base
+
+  let basePath = base
+  if (!basePath.endsWith('/'))
+    basePath = `${basePath}/`
+
+  if (!basePath.startsWith('/') && !basePath.startsWith('./'))
+    basePath = `/${basePath}`
+
+  return basePath
 }
 
 export function isAbsolute(url: string) {


### PR DESCRIPTION
Right now, this plugin assumes that the base path always ends with a forward slash (`/`). However, this is not always the case.

When we set the base as, for example `/app`, the browser will try to download `/appmanifest.webmanifest` and `/appsw.js`

This PR resolves that case.