### PR TITLE
chore: switch to tinyglobby to drop 15 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "pretty-bytes": "^6.1.1",
-    "tinyglobby": "^0.1.2",
+    "tinyglobby": "^0.2.0",
     "workbox-build": "^7.1.0",
     "workbox-window": "^7.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "fast-glob": "^3.3.2",
     "pretty-bytes": "^6.1.1",
+    "tinyglobby": "^0.1.2",
     "workbox-build": "^7.1.0",
     "workbox-window": "^7.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
+      tinyglobby:
+        specifier: ^0.1.2
+        version: 0.1.2
       workbox-build:
         specifier: ^7.1.0
         version: 7.1.0(@types/babel__core@7.20.4)
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.0.0
-        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))
+        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))
       '@antfu/ni':
         specifier: ^0.21.9
         version: 0.21.9
@@ -92,10 +92,10 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
       vitest:
         specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)
+        version: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)
       vue:
         specifier: ^3.3.8
         version: 3.3.8(typescript@5.3.3)
@@ -117,7 +117,7 @@ importers:
         version: 9.0.13
       '@vitejs/plugin-vue':
         specifier: ^3.1.0
-        version: 3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.38)
+        version: 3.1.0(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
       esbuild-register:
         specifier: ^3.3.3
         version: 3.3.3(esbuild@0.19.5)
@@ -138,19 +138,19 @@ importers:
         version: 4.8.2
       unocss:
         specifier: ^0.45.18
-        version: 0.45.18(vite@3.1.0(terser@5.15.0))
+        version: 0.45.18(vite@3.1.0(terser@5.31.0))
       unplugin-vue-components:
         specifier: ^0.22.4
-        version: 0.22.4(@babel/parser@7.23.3)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))(vue@3.2.38)
+        version: 0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
       vite:
         specifier: ^3.1.0
-        version: 3.1.0(terser@5.15.0)
+        version: 3.1.0(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:..
       vitepress:
         specifier: 1.0.0-alpha.13
-        version: 1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.15.0)
+        version: 1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.31.0)
       workbox-window:
         specifier: ^6.5.4
         version: 6.5.4
@@ -174,7 +174,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -193,10 +193,10 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.7.0
-        version: 2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+        version: 2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -208,7 +208,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -245,7 +245,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.37
@@ -260,7 +260,7 @@ importers:
         version: 5.3.3
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+        version: 4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -272,7 +272,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -312,13 +312,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+        version: 2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       workbox-core:
         specifier: ^7.1.0
         version: 7.1.0
@@ -336,13 +336,13 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@roxi/routify':
         specifier: ^2.18.12
         version: 2.18.12
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+        version: 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@tsconfig/svelte':
         specifier: ^5.0.2
         version: 5.0.2
@@ -363,16 +363,16 @@ importers:
         version: 4.2.5
       svelte-check:
         specifier: ^3.6.0
-        version: 3.6.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)
+        version: 3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)
       svelte-preprocess:
         specifier: ^5.1.0
-        version: 5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
+        version: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -393,10 +393,10 @@ importers:
         version: 4.0.0(rollup@4.4.1)
       '@sveltejs/adapter-static':
         specifier: next
-        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))
+        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))
       '@sveltejs/kit':
         specifier: next
-        version: 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+        version: 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.30.3
         version: 5.36.2(@typescript-eslint/parser@5.36.2(eslint@8.54.0)(typescript@4.8.2))(eslint@8.54.0)(typescript@4.8.2)
@@ -426,10 +426,10 @@ importers:
         version: 3.50.0
       svelte-check:
         specifier: ^2.8.0
-        version: 2.9.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)
+        version: 2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)
       svelte-preprocess:
         specifier: ^4.10.7
-        version: 4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2)
+        version: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2)
       tslib:
         specifier: ^2.4.0
         version: 2.4.0
@@ -453,7 +453,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^5.0.0
-        version: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -486,7 +486,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -504,7 +504,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -535,10 +535,10 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@vitejs/plugin-vue':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))
+        version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
       '@vueuse/core':
         specifier: ^10.6.1
         version: 10.6.1(vue@3.3.8(typescript@5.3.3))
@@ -550,7 +550,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -566,10 +566,10 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
-        version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))
+        version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
       '@vueuse/core':
         specifier: ^10.6.1
         version: 10.6.1(vue@3.3.8(typescript@5.3.3))
@@ -584,7 +584,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+        version: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:../..
@@ -1808,9 +1808,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/source-map@0.3.2':
-    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
 
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
@@ -3662,6 +3659,14 @@ packages:
   fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
 
+  fdir@6.2.0:
+    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4709,6 +4714,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pirates@4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
@@ -5428,11 +5437,6 @@ packages:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
     engines: {node: '>=10'}
 
-  terser@5.15.0:
-    resolution: {integrity: sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   terser@5.31.0:
     resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
     engines: {node: '>=10'}
@@ -5453,6 +5457,10 @@ packages:
 
   tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
+
+  tinyglobby@0.1.2:
+    resolution: {integrity: sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@0.8.1:
     resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
@@ -6203,7 +6211,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
 
-  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))':
+  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))':
     dependencies:
       '@antfu/eslint-define-config': 1.23.0-2
       '@eslint-types/jsdoc': 46.8.2-1
@@ -6225,7 +6233,7 @@ snapshots:
       eslint-plugin-perfectionist: 2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2(eslint@8.54.0))
       eslint-plugin-unicorn: 49.0.0(eslint@8.54.0)
       eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)
-      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0))
+      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))
       eslint-plugin-vue: 9.18.1(eslint@8.54.0)
       eslint-plugin-yml: 1.10.0(eslint@8.54.0)
       execa: 8.0.1
@@ -6793,6 +6801,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -6987,10 +7000,10 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.2)':
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -7002,13 +7015,13 @@ snapshots:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2)':
+  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.5)
       '@babel/types': 7.23.0
 
   '@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.24.5)':
@@ -7524,12 +7537,6 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/source-map@0.3.2':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.18
-    optional: true
-
   '@jridgewell/source-map@0.3.6':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
@@ -7582,18 +7589,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.21': {}
 
-  '@preact/preset-vite@2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
+  '@preact/preset-vite@2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.2)
-      '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
+      '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.2)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.24.5)
       debug: 4.3.4
       kolorist: 1.8.0
       resolve: 1.22.8
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -7606,7 +7613,7 @@ snapshots:
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
+  '@prefresh/vite@2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@babel/core': 7.23.2
       '@prefresh/babel-plugin': 0.5.0
@@ -7614,7 +7621,7 @@ snapshots:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.17.1
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7652,12 +7659,12 @@ snapshots:
       magic-string: 0.25.9
       rollup: 4.4.1
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.4.1)':
+  '@rollup/plugin-replace@5.0.5(rollup@2.79.0)':
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@4.4.1)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.0)
       magic-string: 0.30.3
     optionalDependencies:
-      rollup: 4.4.1
+      rollup: 2.79.0
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.0)':
     dependencies:
@@ -7693,14 +7700,6 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 2.79.0
-
-  '@rollup/pluginutils@5.0.2(rollup@4.4.1)':
-    dependencies:
-      '@types/estree': 1.0.1
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.4.1
 
   '@rollup/rollup-android-arm-eabi@4.4.1':
     optional: true
@@ -7813,13 +7812,13 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.7
 
-  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))':
+  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))':
     dependencies:
-      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
 
-  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
+  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.2.0
@@ -7833,53 +7832,53 @@ snapshots:
       svelte: 3.50.0
       tiny-glob: 0.2.9
       undici: 5.14.0
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.3.4
       svelte: 3.50.0
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.3.4
       svelte: 4.2.5
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))':
+  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.3
       svelte: 3.50.0
       svelte-hmr: 0.15.3(svelte@3.50.0)
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
-      vitefu: 0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0))
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
+      vitefu: 0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
+  '@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.2.5
       svelte-hmr: 0.15.3(svelte@4.2.5)
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
-      vitefu: 0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
+      vitefu: 0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8180,11 +8179,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/astro@0.45.18(vite@3.1.0(terser@5.15.0))':
+  '@unocss/astro@0.45.18(vite@3.1.0(terser@5.31.0))':
     dependencies:
       '@unocss/core': 0.45.18
       '@unocss/reset': 0.45.18
-      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.15.0))
+      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.31.0))
     transitivePeerDependencies:
       - vite
 
@@ -8274,7 +8273,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.45.18
 
-  '@unocss/vite@0.45.18(vite@3.1.0(terser@5.15.0))':
+  '@unocss/vite@0.45.18(vite@3.1.0(terser@5.31.0))':
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@rollup/pluginutils': 4.2.1
@@ -8284,7 +8283,7 @@ snapshots:
       '@unocss/scope': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       magic-string: 0.26.7
-      vite: 3.1.0(terser@5.15.0)
+      vite: 3.1.0(terser@5.31.0)
 
   '@vite-pwa/assets-generator@0.2.4':
     dependencies:
@@ -8295,35 +8294,35 @@ snapshots:
       sharp-ico: 0.1.5
       unconfig: 0.3.11
 
-  '@vitejs/plugin-react@4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))':
+  '@vitejs/plugin-react@4.2.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.3)
       '@types/babel__core': 7.20.4
       react-refresh: 0.14.0
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.38)':
+  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.31.0))(vue@3.2.38)':
     dependencies:
-      vite: 3.1.0(terser@5.15.0)
+      vite: 3.1.0(terser@5.31.0)
       vue: 3.2.38
 
-  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.45)':
+  '@vitejs/plugin-vue@3.1.0(vite@3.1.0(terser@5.31.0))(vue@3.2.45)':
     dependencies:
-      vite: 3.1.0(terser@5.15.0)
+      vite: 3.1.0(terser@5.31.0)
       vue: 3.2.45
 
-  '@vitejs/plugin-vue@4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))':
+  '@vitejs/plugin-vue@4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vue: 3.3.8(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))(vue@3.3.8(typescript@5.3.3))':
+  '@vitejs/plugin-vue@4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
       vue: 3.3.8(typescript@5.3.3)
 
   '@vitest/expect@1.0.0-beta.4':
@@ -8758,9 +8757,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.23.2):
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
 
   babel-preset-solid@1.8.4(@babel/core@7.23.2):
     dependencies:
@@ -9582,13 +9581,13 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
 
-  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)):
+  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)):
     dependencies:
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
-      vitest: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0)
+      vitest: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9814,6 +9813,10 @@ snapshots:
   fastq@1.13.0:
     dependencies:
       reusify: 1.0.4
+
+  fdir@6.2.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -10814,6 +10817,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pirates@4.0.5: {}
 
   pkg-types@1.0.3:
@@ -11478,7 +11483,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@2.9.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0):
+  svelte-check@2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.15
       chokidar: 3.5.3
@@ -11487,7 +11492,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.50.0
-      svelte-preprocess: 4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4)
+      svelte-preprocess: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -11501,7 +11506,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.6.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5):
+  svelte-check@3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       chokidar: 3.5.3
@@ -11510,7 +11515,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.5
-      svelte-preprocess: 5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
+      svelte-preprocess: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -11531,7 +11536,7 @@ snapshots:
     dependencies:
       svelte: 4.2.5
 
-  svelte-preprocess@4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2):
+  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.8.2):
     dependencies:
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
@@ -11541,12 +11546,12 @@ snapshots:
       strip-indent: 3.0.0
       svelte: 3.50.0
     optionalDependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.5
       postcss: 8.4.32
       postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 4.8.2
 
-  svelte-preprocess@4.10.7(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4):
+  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@3.50.0)(typescript@4.9.4):
     dependencies:
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
@@ -11556,12 +11561,12 @@ snapshots:
       strip-indent: 3.0.0
       svelte: 3.50.0
     optionalDependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.5
       postcss: 8.4.32
       postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 4.9.4
 
-  svelte-preprocess@5.1.0(@babel/core@7.23.3)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3):
+  svelte-preprocess@5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.32))(postcss@8.4.32)(svelte@4.2.5)(typescript@5.3.3):
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
@@ -11570,7 +11575,7 @@ snapshots:
       strip-indent: 3.0.0
       svelte: 4.2.5
     optionalDependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.5
       postcss: 8.4.32
       postcss-load-config: 4.0.1(postcss@8.4.32)
       typescript: 5.3.3
@@ -11640,14 +11645,6 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser@5.15.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.11.2
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
-
   terser@5.31.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
@@ -11671,6 +11668,11 @@ snapshots:
       globrex: 0.1.2
 
   tinybench@2.5.0: {}
+
+  tinyglobby@0.1.2:
+    dependencies:
+      fdir: 6.2.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@0.8.1: {}
 
@@ -11839,9 +11841,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.45.18(vite@3.1.0(terser@5.15.0)):
+  unocss@0.45.18(vite@3.1.0(terser@5.31.0)):
     dependencies:
-      '@unocss/astro': 0.45.18(vite@3.1.0(terser@5.15.0))
+      '@unocss/astro': 0.45.18(vite@3.1.0(terser@5.31.0))
       '@unocss/cli': 0.45.18
       '@unocss/core': 0.45.18
       '@unocss/preset-attributify': 0.45.18
@@ -11857,14 +11859,14 @@ snapshots:
       '@unocss/transformer-compile-class': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       '@unocss/transformer-variant-group': 0.45.18
-      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.15.0))
+      '@unocss/vite': 0.45.18(vite@3.1.0(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
       - vite
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.22.4(@babel/parser@7.23.3)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))(vue@3.2.38):
+  unplugin-vue-components@0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -11875,10 +11877,10 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0))
+      unplugin: 0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))
       vue: 3.2.38
     optionalDependencies:
-      '@babel/parser': 7.23.3
+      '@babel/parser': 7.24.5
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -11886,7 +11888,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.15.0)):
+  unplugin@0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0)):
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
@@ -11894,8 +11896,8 @@ snapshots:
       webpack-virtual-modules: 0.4.4
     optionalDependencies:
       esbuild: 0.19.5
-      rollup: 4.4.1
-      vite: 3.1.0(terser@5.15.0)
+      rollup: 2.79.0
+      vite: 3.1.0(terser@5.31.0)
 
   upath@1.2.0: {}
 
@@ -11937,14 +11939,14 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@1.0.0-beta.4(@types/node@18.17.14)(terser@5.15.0):
+  vite-node@1.0.0-beta.4(@types/node@18.17.14)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11955,7 +11957,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
+  vite-plugin-solid@2.7.2(solid-js@1.8.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)):
     dependencies:
       '@babel/core': 7.23.2
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
@@ -11964,12 +11966,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.5
       solid-refresh: 0.5.3(solid-js@1.8.5)
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
-      vitefu: 0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0))
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
+      vitefu: 0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@3.1.0(terser@5.15.0):
+  vite@3.1.0(terser@5.31.0):
     dependencies:
       esbuild: 0.15.7
       postcss: 8.4.20
@@ -11977,9 +11979,9 @@ snapshots:
       rollup: 2.78.1
     optionalDependencies:
       fsevents: 2.3.3
-      terser: 5.15.0
+      terser: 5.31.0
 
-  vite@5.0.10(@types/node@18.17.14)(terser@5.15.0):
+  vite@5.0.10(@types/node@18.17.14)(terser@5.31.0):
     dependencies:
       esbuild: 0.19.5
       postcss: 8.4.32
@@ -11987,9 +11989,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.17.14
       fsevents: 2.3.3
-      terser: 5.15.0
+      terser: 5.31.0
 
-  vite@5.0.12(@types/node@18.17.14)(terser@5.15.0):
+  vite@5.0.12(@types/node@18.17.14)(terser@5.31.0):
     dependencies:
       esbuild: 0.19.5
       postcss: 8.4.32
@@ -11997,30 +11999,30 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.17.14
       fsevents: 2.3.3
-      terser: 5.15.0
+      terser: 5.31.0
 
-  vitefu@0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
+  vitefu@0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
 
-  vitefu@0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.15.0)):
+  vitefu@0.2.4(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
 
-  vitefu@0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.15.0)):
+  vitefu@0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
-      vite: 5.0.10(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
 
-  vitepress@1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.15.0):
+  vitepress@1.0.0-alpha.13(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(terser@5.31.0):
     dependencies:
       '@docsearch/css': 3.2.1
       '@docsearch/js': 3.2.1(@algolia/client-search@4.14.2)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@vitejs/plugin-vue': 3.1.0(vite@3.1.0(terser@5.15.0))(vue@3.2.45)
+      '@vitejs/plugin-vue': 3.1.0(vite@3.1.0(terser@5.31.0))(vue@3.2.45)
       '@vue/devtools-api': 6.4.5
       '@vueuse/core': 9.6.0(vue@3.2.45)
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.11.1
-      vite: 3.1.0(terser@5.15.0)
+      vite: 3.1.0(terser@5.31.0)
       vue: 3.2.45
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -12033,7 +12035,7 @@ snapshots:
       - stylus
       - terser
 
-  vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.15.0):
+  vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0):
     dependencies:
       '@vitest/expect': 1.0.0-beta.4
       '@vitest/runner': 1.0.0-beta.4
@@ -12053,8 +12055,8 @@ snapshots:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.8.1
-      vite: 5.0.12(@types/node@18.17.14)(terser@5.15.0)
-      vite-node: 1.0.0-beta.4(@types/node@18.17.14)(terser@5.15.0)
+      vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
+      vite-node: 1.0.0-beta.4(@types/node@18.17.14)(terser@5.31.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 18.17.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1
       tinyglobby:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.2.0
+        version: 0.2.0
       workbox-build:
         specifier: ^7.1.0
         version: 7.1.0(@types/babel__core@7.20.4)
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.0.0
-        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))
+        version: 2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0))
       '@antfu/ni':
         specifier: ^0.21.9
         version: 0.21.9
@@ -95,7 +95,7 @@ importers:
         version: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
       vitest:
         specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)
+        version: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0)
       vue:
         specifier: ^3.3.8
         version: 3.3.8(typescript@5.3.3)
@@ -141,7 +141,7 @@ importers:
         version: 0.45.18(vite@3.1.0(terser@5.31.0))
       unplugin-vue-components:
         specifier: ^0.22.4
-        version: 0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
+        version: 0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
       vite:
         specifier: ^3.1.0
         version: 3.1.0(terser@5.31.0)
@@ -193,10 +193,10 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.7.0
-        version: 2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
+        version: 2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -245,7 +245,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.37
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -336,7 +336,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       '@roxi/routify':
         specifier: ^2.18.12
         version: 2.18.12
@@ -535,7 +535,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       '@vitejs/plugin-vue':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@2.79.0)
+        version: 5.0.5(rollup@4.4.1)
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
         version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -5458,8 +5458,8 @@ packages:
   tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
 
-  tinyglobby@0.1.2:
-    resolution: {integrity: sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==}
+  tinyglobby@0.2.0:
+    resolution: {integrity: sha512-+clyYQfAnNlt5a1x7CCQ6RLuTIztDfDAl6mAANvqRUlz6sVy5znCzJOhais8G6oyUyoeeaorLopO3HptVP8niA==}
     engines: {node: '>=12.0.0'}
 
   tinypool@0.8.1:
@@ -6211,7 +6211,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
 
-  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))':
+  '@antfu/eslint-config@2.0.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0))':
     dependencies:
       '@antfu/eslint-define-config': 1.23.0-2
       '@eslint-types/jsdoc': 46.8.2-1
@@ -6233,7 +6233,7 @@ snapshots:
       eslint-plugin-perfectionist: 2.4.0(eslint@8.54.0)(svelte@4.2.5)(typescript@5.3.3)(vue-eslint-parser@9.3.2(eslint@8.54.0))
       eslint-plugin-unicorn: 49.0.0(eslint@8.54.0)
       eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)
-      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0))
+      eslint-plugin-vitest: 0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0))
       eslint-plugin-vue: 9.18.1(eslint@8.54.0)
       eslint-plugin-yml: 1.10.0(eslint@8.54.0)
       execa: 8.0.1
@@ -6801,11 +6801,6 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -7000,10 +6995,10 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5)':
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.2)':
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -7015,13 +7010,13 @@ snapshots:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.24.5)':
+  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2)':
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@babel/types': 7.23.0
 
   '@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.24.5)':
@@ -7589,14 +7584,14 @@ snapshots:
 
   '@polka/url@1.0.0-next.21': {}
 
-  '@preact/preset-vite@2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
+  '@preact/preset-vite@2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.2)
       '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.24.5)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.2)
       debug: 4.3.4
       kolorist: 1.8.0
       resolve: 1.22.8
@@ -7659,12 +7654,12 @@ snapshots:
       magic-string: 0.25.9
       rollup: 4.4.1
 
-  '@rollup/plugin-replace@5.0.5(rollup@2.79.0)':
+  '@rollup/plugin-replace@5.0.5(rollup@4.4.1)':
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.0)
+      '@rollup/pluginutils': 5.0.2(rollup@4.4.1)
       magic-string: 0.30.3
     optionalDependencies:
-      rollup: 2.79.0
+      rollup: 4.4.1
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.0)':
     dependencies:
@@ -7700,6 +7695,14 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 2.79.0
+
+  '@rollup/pluginutils@5.0.2(rollup@4.4.1)':
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.4.1
 
   '@rollup/rollup-android-arm-eabi@4.4.1':
     optional: true
@@ -8757,9 +8760,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.24.5):
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.23.2):
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.23.2
 
   babel-preset-solid@1.8.4(@babel/core@7.23.2):
     dependencies:
@@ -9581,13 +9584,13 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
 
-  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)):
+  eslint-plugin-vitest@0.3.10(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)(vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0)):
     dependencies:
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       eslint: 8.54.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
-      vitest: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0)
+      vitest: 1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11669,7 +11672,7 @@ snapshots:
 
   tinybench@2.5.0: {}
 
-  tinyglobby@0.1.2:
+  tinyglobby@0.2.0:
     dependencies:
       fdir: 6.2.0(picomatch@4.0.2)
       picomatch: 4.0.2
@@ -11866,7 +11869,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38):
+  unplugin-vue-components@0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))(vue@3.2.38):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -11877,7 +11880,7 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))
+      unplugin: 0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))
       vue: 3.2.38
     optionalDependencies:
       '@babel/parser': 7.24.5
@@ -11888,7 +11891,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0)):
+  unplugin@0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0)):
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
@@ -11896,7 +11899,7 @@ snapshots:
       webpack-virtual-modules: 0.4.4
     optionalDependencies:
       esbuild: 0.19.5
-      rollup: 2.79.0
+      rollup: 4.4.1
       vite: 3.1.0(terser@5.31.0)
 
   upath@1.2.0: {}
@@ -12035,7 +12038,7 @@ snapshots:
       - stylus
       - terser
 
-  vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0)(terser@5.31.0):
+  vitest@1.0.0-beta.4(@types/node@18.17.14)(jsdom@16.7.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(terser@5.31.0):
     dependencies:
       '@vitest/expect': 1.0.0-beta.4
       '@vitest/runner': 1.0.0-beta.4

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,7 +1,7 @@
 import { resolve as resolveFs } from 'node:path'
 import fs from 'node:fs'
 import crypto from 'node:crypto'
-import tg from 'tinyglobby'
+import { glob } from 'tinyglobby'
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
 import type { ResolvedConfig } from 'vite'
 import type { ResolvedVitePWAOptions } from './types'
@@ -90,14 +90,12 @@ export async function configureStaticAssets(
     })
   }
   if (globs.length > 0) {
-    let assets = await tg(
-      globs,
-      {
-        cwd: publicDir,
-        expandDirectories: false,
-        onlyFiles: true,
-      },
-    )
+    let assets = await glob({
+      patterns: globs,
+      cwd: publicDir,
+      expandDirectories: false,
+      onlyFiles: true,
+    })
     // we also need to remove from the list existing included by the user
     if (manifestEntries.length > 0) {
       const included = manifestEntries.map((me) => {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,7 +1,7 @@
 import { resolve as resolveFs } from 'node:path'
 import fs from 'node:fs'
 import crypto from 'node:crypto'
-import fg from 'fast-glob'
+import tg from 'tinyglobby'
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
 import type { ResolvedConfig } from 'vite'
 import type { ResolvedVitePWAOptions } from './types'
@@ -90,12 +90,12 @@ export async function configureStaticAssets(
     })
   }
   if (globs.length > 0) {
-    let assets = await fg(
+    let assets = await tg(
       globs,
       {
         cwd: publicDir,
+        expandDirectories: false,
         onlyFiles: true,
-        unique: true,
       },
     )
     // we also need to remove from the list existing included by the user


### PR DESCRIPTION
https://npmgraph.js.org/?q=fast-glob - 17 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies