### PR TITLE
feat: throw error when `maximumFileSizeToCacheInBytes` found in sw build warnings

### DIFF
--- a/examples/vue-router/vite.config.ts
+++ b/examples/vue-router/vite.config.ts
@@ -35,10 +35,10 @@ const pwaOptions: Partial<VitePWAOptions> = {
       },
     ],
   },
-  /* showMaximumFileSizeToCacheInBytesWarning: true,
-  workbox: {
-    maximumFileSizeToCacheInBytes: 12000,
-  }, */
+  // showMaximumFileSizeToCacheInBytesWarning: true,
+  // workbox: {
+  //   maximumFileSizeToCacheInBytes: 12000,
+  // },
   devOptions: {
     enabled: process.env.SW_DEV === 'true',
     /* when using generateSW the PWA plugin will switch to classic */
@@ -85,6 +85,7 @@ if (process.env.SW === 'true') {
     buildPlugins: {
       vite: [virtualMessagePlugin()],
     },
+    // maximumFileSizeToCacheInBytes: 1000,
   }
 }
 

--- a/examples/vue-router/vite.config.ts
+++ b/examples/vue-router/vite.config.ts
@@ -35,6 +35,10 @@ const pwaOptions: Partial<VitePWAOptions> = {
       },
     ],
   },
+  /* showMaximumFileSizeToCacheInBytesWarning: true,
+  workbox: {
+    maximumFileSizeToCacheInBytes: 12000,
+  }, */
   devOptions: {
     enabled: process.env.SW_DEV === 'true',
     /* when using generateSW the PWA plugin will switch to classic */

--- a/src/log.ts
+++ b/src/log.ts
@@ -35,7 +35,7 @@ export function logWorkboxResult(
   if (throwMaximumFileSizeToCacheInBytes) {
     const entries = buildResult.warnings.filter(w => w.includes('maximumFileSizeToCacheInBytes'))
     if (entries.length)
-      throw new Error(entries.join('\n'))
+      throw new Error(`\n${entries.map(w => `  - ${w}`).join('\n')}`)
   }
 
   const { root, logLevel = 'info' } = viteOptions

--- a/src/log.ts
+++ b/src/log.ts
@@ -26,11 +26,18 @@ export function logSWViteBuild(
 }
 
 export function logWorkboxResult(
+  throwMaximumFileSizeToCacheInBytes: boolean,
   strategy: ResolvedVitePWAOptions['strategies'],
   buildResult: BuildResult,
   viteOptions: ResolvedConfig,
   format: 'es' | 'iife' | 'none' = 'none',
 ) {
+  if (throwMaximumFileSizeToCacheInBytes) {
+    const entries = buildResult.warnings.filter(w => w.includes('maximumFileSizeToCacheInBytes'))
+    if (entries.length)
+      throw new Error(entries.join('\n'))
+  }
+
   const { root, logLevel = 'info' } = viteOptions
 
   if (logLevel === 'silent')

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -82,7 +82,12 @@ self.addEventListener('activate', (e) => {
   // generate the service worker
   const buildResult = await generateSW(options.workbox)
   // log workbox result
-  logWorkboxResult('generateSW', buildResult, viteOptions)
+  logWorkboxResult(
+    options.throwMaximumFileSizeToCacheInBytes,
+    'generateSW',
+    buildResult,
+    viteOptions,
+  )
 
   return buildResult
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -62,6 +62,7 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
     integration = {},
     buildBase,
     pwaAssets,
+    showMaximumFileSizeToCacheInBytesWarning = false,
   } = options
 
   const basePath = resolveBasePath(base)
@@ -224,6 +225,7 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
       envPrefix,
     },
     pwaAssets: resolvePWAAssetsOptions(pwaAssets),
+    throwMaximumFileSizeToCacheInBytes: !showMaximumFileSizeToCacheInBytesWarning,
   }
 
   // calculate hash only when required

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,6 +393,15 @@ export interface VitePWAOptions {
    * @experimental
    */
   pwaAssets?: PWAAssetsOptions
+
+  /**
+   * From version `0.20.2`, the plugin will throw an error if the `maximumFileSizeToCacheInBytes` warning is present when building the service worker.
+   *
+   * If you want the old behavior when building the service worker, set this option to `true`.
+   *
+   * @default false
+   */
+  showMaximumFileSizeToCacheInBytesWarning?: boolean
 }
 
 export interface ResolvedServiceWorkerOptions {
@@ -401,7 +410,7 @@ export interface ResolvedServiceWorkerOptions {
   rollupOptions: RollupOptions
 }
 
-export interface ResolvedVitePWAOptions extends Required<Omit<VitePWAOptions, 'pwaAssets'>> {
+export interface ResolvedVitePWAOptions extends Required<Omit<VitePWAOptions, 'pwaAssets' | 'showMaximumFileSizeToCacheInBytesWarning'>> {
   swSrc: string
   swDest: string
   workbox: GenerateSWOptions
@@ -421,6 +430,7 @@ export interface ResolvedVitePWAOptions extends Required<Omit<VitePWAOptions, 'p
     envPrefix: ResolvedConfig['envPrefix']
   }
   pwaAssets: false | ResolvedPWAAssetsOptions
+  throwMaximumFileSizeToCacheInBytes: boolean
 }
 
 export interface ShareTargetFiles {

--- a/src/vite-build.ts
+++ b/src/vite-build.ts
@@ -72,7 +72,13 @@ export async function buildSW(
   // inject the manifest
   const buildResult = await injectManifest(injectManifestOptions)
   // log workbox result
-  logWorkboxResult('injectManifest', buildResult, viteOptions, format)
+  logWorkboxResult(
+    options.throwMaximumFileSizeToCacheInBytes,
+    'injectManifest',
+    buildResult,
+    viteOptions,
+    format,
+  )
 }
 
 function prepareViteBuild(


### PR DESCRIPTION
### Description

![imagen](https://github.com/user-attachments/assets/9c4480ec-fd0c-427f-81a1-c31edf8dadc1)

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

closes #458
closes #717
<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
