### PR TITLE
feat(injectManifest): optimize workbox load

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "test:vite-ecosystem-ci": "nr test-typescript"
   },
   "peerDependencies": {
-    "@vite-pwa/assets-generator": "^0.2.4",
+    "@vite-pwa/assets-generator": "^0.2.6",
     "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
     "workbox-build": "^7.1.0",
     "workbox-window": "^7.1.0"
@@ -136,7 +136,7 @@
     "@types/prompts": "^2.4.8",
     "@types/react": "^18.2.21",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
-    "@vite-pwa/assets-generator": "^0.2.4",
+    "@vite-pwa/assets-generator": "^0.2.6",
     "bumpp": "^9.2.0",
     "eslint": "^8.54.0",
     "esno": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "./pwa-assets": {
       "types": "./pwa-assets.d.ts"
     },
+    "./package.json": "./package.json",
     "./*": "./*"
   },
   "main": "dist/index.cjs",
@@ -120,7 +121,7 @@
     }
   },
   "dependencies": {
-    "debug": "^4.3.4",
+    "debug": "^4.3.6",
     "pretty-bytes": "^6.1.1",
     "tinyglobby": "^0.2.0",
     "workbox-build": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^6.11.0
         version: 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.3.3))(eslint@8.54.0)(typescript@5.3.3)
       '@vite-pwa/assets-generator':
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: ^0.2.6
+        version: 0.2.6
       bumpp:
         specifier: ^9.2.0
         version: 9.2.0
@@ -2390,6 +2390,11 @@ packages:
 
   '@vite-pwa/assets-generator@0.2.4':
     resolution: {integrity: sha512-DXyPLPR/IpbZPSpo1amZEPghY/ziIwpTUKNaz0v1xG+ELzCXmrVQhVzEMqr2JLSqRxjc+UzKfGJA/YdUuaao3w==}
+    engines: {node: '>=16.14.0'}
+    hasBin: true
+
+  '@vite-pwa/assets-generator@0.2.6':
+    resolution: {integrity: sha512-kK44dXltvoubEo5B+6tCGjUrOWOE1+dA4DForbFpO1rKy2wSkAVGrs8tyfN6DzTig89/QKyV8XYodgmaKyrYng==}
     engines: {node: '>=16.14.0'}
     hasBin: true
 
@@ -8295,6 +8300,15 @@ snapshots:
       vite: 3.1.0(terser@5.31.0)
 
   '@vite-pwa/assets-generator@0.2.4':
+    dependencies:
+      cac: 6.7.14
+      colorette: 2.0.20
+      consola: 3.2.3
+      sharp: 0.32.6
+      sharp-ico: 0.1.5
+      unconfig: 0.3.11
+
+  '@vite-pwa/assets-generator@0.2.6':
     dependencies:
       cac: 6.7.14
       colorette: 2.0.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       debug:
-        specifier: ^4.3.4
-        version: 4.3.4
+        specifier: ^4.3.6
+        version: 4.3.6
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -141,7 +141,7 @@ importers:
         version: 0.45.18(vite@3.1.0(terser@5.31.0))
       unplugin-vue-components:
         specifier: ^0.22.4
-        version: 0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
+        version: 0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38)
       vite:
         specifier: ^3.1.0
         version: 3.1.0(terser@5.31.0)
@@ -193,10 +193,10 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.7.0
-        version: 2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
+        version: 2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -245,7 +245,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.37
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -336,7 +336,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@roxi/routify':
         specifier: ^2.18.12
         version: 2.18.12
@@ -535,7 +535,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@vitejs/plugin-vue':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.4.1)
+        version: 5.0.5(rollup@2.79.0)
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
         version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -3061,6 +3061,15 @@ packages:
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.6:
+    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -6303,7 +6312,7 @@ snapshots:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6323,7 +6332,7 @@ snapshots:
       '@babel/traverse': 7.23.3
       '@babel/types': 7.23.3
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6343,7 +6352,7 @@ snapshots:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6440,7 +6449,7 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.6
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -6801,6 +6810,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -6995,10 +7009,10 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.2)':
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -7010,13 +7024,13 @@ snapshots:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2)':
+  '@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.5)
       '@babel/types': 7.23.0
 
   '@babel/plugin-transform-regenerator@7.18.6(@babel/core@7.24.5)':
@@ -7200,7 +7214,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.3
       '@babel/types': 7.23.3
-      debug: 4.3.4
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7215,7 +7229,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.3
       '@babel/types': 7.23.3
-      debug: 4.3.4
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7230,7 +7244,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7458,7 +7472,7 @@ snapshots:
   '@eslint/eslintrc@2.1.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.6
       espree: 9.6.1
       globals: 13.23.0
       ignore: 5.2.4
@@ -7474,7 +7488,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.13':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
-      debug: 4.3.4
+      debug: 4.3.6
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7490,7 +7504,7 @@ snapshots:
       '@antfu/install-pkg': 0.1.0
       '@antfu/utils': 0.5.2
       '@iconify/types': 1.1.0
-      debug: 4.3.4
+      debug: 4.3.6
       kolorist: 1.8.0
       local-pkg: 0.4.3
     transitivePeerDependencies:
@@ -7584,14 +7598,14 @@ snapshots:
 
   '@polka/url@1.0.0-next.21': {}
 
-  '@preact/preset-vite@2.7.0(@babel/core@7.23.2)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
+  '@preact/preset-vite@2.7.0(@babel/core@7.24.5)(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
       '@prefresh/vite': 2.4.1(preact@10.17.1)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.2)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.24.5)
       debug: 4.3.4
       kolorist: 1.8.0
       resolve: 1.22.8
@@ -7654,12 +7668,12 @@ snapshots:
       magic-string: 0.25.9
       rollup: 4.4.1
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.4.1)':
+  '@rollup/plugin-replace@5.0.5(rollup@2.79.0)':
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@4.4.1)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.0)
       magic-string: 0.30.3
     optionalDependencies:
-      rollup: 4.4.1
+      rollup: 2.79.0
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.0)':
     dependencies:
@@ -7695,14 +7709,6 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 2.79.0
-
-  '@rollup/pluginutils@5.0.2(rollup@4.4.1)':
-    dependencies:
-      '@types/estree': 1.0.1
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.4.1
 
   '@rollup/rollup-android-arm-eabi@4.4.1':
     optional: true
@@ -7842,7 +7848,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
-      debug: 4.3.4
+      debug: 4.3.6
       svelte: 3.50.0
       vite: 5.0.12(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
@@ -7851,7 +7857,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)))(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.5)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
-      debug: 4.3.4
+      debug: 4.3.6
       svelte: 4.2.5
       vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
@@ -7860,7 +7866,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.0.12(@types/node@18.17.14)(terser@5.31.0))
-      debug: 4.3.4
+      debug: 4.3.6
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.3
@@ -8040,7 +8046,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.11.0
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -8070,7 +8076,7 @@ snapshots:
       '@typescript-eslint/types': 6.11.0
       '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.11.0
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
     optionalDependencies:
       typescript: 5.3.3
@@ -8091,7 +8097,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.36.2(typescript@4.8.2)
       '@typescript-eslint/utils': 5.36.2(eslint@8.54.0)(typescript@4.8.2)
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
       tsutils: 3.21.0(typescript@4.8.2)
     optionalDependencies:
@@ -8103,7 +8109,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.3.3)
       '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
       ts-api-utils: 1.0.3(typescript@5.3.3)
     optionalDependencies:
@@ -8119,7 +8125,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.36.2
       '@typescript-eslint/visitor-keys': 5.36.2
-      debug: 4.3.4
+      debug: 4.3.6
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -8133,7 +8139,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.11.0
       '@typescript-eslint/visitor-keys': 6.11.0
-      debug: 4.3.4
+      debug: 4.3.6
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -8630,7 +8636,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8760,9 +8766,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.23.2):
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
 
   babel-preset-solid@1.8.4(@babel/core@7.23.2):
     dependencies:
@@ -9117,6 +9123,10 @@ snapshots:
       ms: 2.1.3
 
   debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
+  debug@4.3.6:
     dependencies:
       ms: 2.1.2
 
@@ -9495,7 +9505,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.41.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.3.4
+      debug: 4.3.6
       escape-string-regexp: 4.0.0
       eslint: 8.54.0
       esquery: 1.5.0
@@ -9610,7 +9620,7 @@ snapshots:
 
   eslint-plugin-yml@1.10.0(eslint@8.54.0):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
       eslint-compat-utils: 0.1.2(eslint@8.54.0)
       lodash: 4.17.21
@@ -10095,7 +10105,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -10113,7 +10123,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -10517,7 +10527,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -11352,7 +11362,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -11363,7 +11373,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -11727,7 +11737,7 @@ snapshots:
       bundle-require: 4.0.1(esbuild@0.19.5)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4
+      debug: 4.3.6
       esbuild: 0.19.5
       execa: 5.1.1
       globby: 11.1.0
@@ -11869,7 +11879,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))(vue@3.2.38):
+  unplugin-vue-components@0.22.4(@babel/parser@7.24.5)(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))(vue@3.2.38):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -11880,7 +11890,7 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0))
+      unplugin: 0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0))
       vue: 3.2.38
     optionalDependencies:
       '@babel/parser': 7.24.5
@@ -11891,7 +11901,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.9.5(esbuild@0.19.5)(rollup@4.4.1)(vite@3.1.0(terser@5.31.0)):
+  unplugin@0.9.5(esbuild@0.19.5)(rollup@2.79.0)(vite@3.1.0(terser@5.31.0)):
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
@@ -11899,7 +11909,7 @@ snapshots:
       webpack-virtual-modules: 0.4.4
     optionalDependencies:
       esbuild: 0.19.5
-      rollup: 4.4.1
+      rollup: 2.79.0
       vite: 3.1.0(terser@5.31.0)
 
   upath@1.2.0: {}
@@ -11945,7 +11955,7 @@ snapshots:
   vite-node@1.0.0-beta.4(@types/node@18.17.14)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.6
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -12049,7 +12059,7 @@ snapshots:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.10
-      debug: 4.3.4
+      debug: 4.3.6
       local-pkg: 0.4.3
       magic-string: 0.30.5
       pathe: 1.1.1
@@ -12091,7 +12101,7 @@ snapshots:
 
   vue-eslint-parser@9.3.2(eslint@8.54.0):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       eslint: 8.54.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,14 +14,14 @@ import {
 import type { PWAPluginContext } from './context'
 import type { ExtendManifestEntriesHook, VitePluginPWAAPI } from './types'
 
-export async function _generateSW({ options, viteConfig }: PWAPluginContext) {
+export async function _generateSW({ options, version, viteConfig }: PWAPluginContext) {
   if (options.disable)
     return
 
   if (options.strategies === 'injectManifest')
-    await generateInjectManifest(options, viteConfig)
+    await generateInjectManifest(version, options, viteConfig)
   else
-    await generateServiceWorker(options, viteConfig)
+    await generateServiceWorker(version, options, viteConfig)
 }
 
 export function _generateBundle(ctx: PWAPluginContext, bundle?: OutputBundle) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { ResolvedConfig } from 'vite'
-import { version } from '../package.json'
 import type { ResolvedVitePWAOptions, VitePWAOptions } from './types'
 import type { PWAAssetsGenerator } from './pwa-assets/types'
 
@@ -14,6 +16,12 @@ export interface PWAPluginContext {
 }
 
 export function createContext(userOptions: Partial<VitePWAOptions>): PWAPluginContext {
+  const _dirname = typeof __dirname !== 'undefined'
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url))
+  const { version } = JSON.parse(
+    readFileSync(resolve(_dirname, '../package.json'), 'utf-8'),
+  )
   return {
     version,
     userOptions,

--- a/src/log.ts
+++ b/src/log.ts
@@ -3,11 +3,11 @@ import { relative } from 'node:path'
 import type { BuildResult } from 'workbox-build'
 import type { ResolvedConfig } from 'vite'
 import { cyan, dim, green, magenta, yellow } from 'kolorist'
-import { version } from '../package.json'
 import { normalizePath } from './utils'
 import type { ResolvedVitePWAOptions } from './types'
 
 export function logSWViteBuild(
+  version: string,
   swName: string,
   viteOptions: ResolvedConfig,
   format: 'es' | 'iife',
@@ -26,6 +26,7 @@ export function logSWViteBuild(
 }
 
 export function logWorkboxResult(
+  version: string,
   throwMaximumFileSizeToCacheInBytes: boolean,
   strategy: ResolvedVitePWAOptions['strategies'],
   buildResult: BuildResult,

--- a/src/log.ts
+++ b/src/log.ts
@@ -35,8 +35,15 @@ export function logWorkboxResult(
 ) {
   if (throwMaximumFileSizeToCacheInBytes) {
     const entries = buildResult.warnings.filter(w => w.includes('maximumFileSizeToCacheInBytes'))
-    if (entries.length)
-      throw new Error(`\n${entries.map(w => `  - ${w}`).join('\n')}`)
+    if (entries.length) {
+      const prefix = strategy === 'generateSW' ? 'workbox' : 'injectManifest'
+      throw new Error(`
+  Configure "${prefix}.maximumFileSizeToCacheInBytes" to change the limit: the default value is 2 MiB.
+  Check https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest for more information.
+  Assets exceeding the limit:
+${entries.map(w => `  - ${w.replace('. Configure maximumFileSizeToCacheInBytes to change this limit', '')}`).join('\n')}
+`)
+    }
   }
 
   const { root, logLevel = 'info' } = viteOptions

--- a/src/vite-build.ts
+++ b/src/vite-build.ts
@@ -6,9 +6,10 @@ import { logSWViteBuild, logWorkboxResult } from './log'
 import { normalizePath } from './utils'
 
 export async function buildSW(
+  version: string,
   options: ResolvedVitePWAOptions,
   viteOptions: ResolvedConfig,
-  workbox: typeof import('workbox-build'),
+  workboxPromise: Promise<typeof import('workbox-build')>,
 ) {
   // we will have something like this from swSrc:
   /*
@@ -31,7 +32,7 @@ export async function buildSW(
   } = prepareViteBuild(options, viteOptions)
 
   // log sw build
-  logSWViteBuild(normalizePath(relative(viteOptions.root, options.swSrc)), viteOptions, format)
+  logSWViteBuild(version, normalizePath(relative(viteOptions.root, options.swSrc)), viteOptions, format)
 
   // allow integrations to modify the build config
   await options.integration?.configureCustomSWViteBuild?.(inlineConfig)
@@ -67,12 +68,13 @@ export async function buildSW(
     swSrc: options.injectManifest.swDest,
   }
 
-  const { injectManifest } = workbox
+  const { injectManifest } = await workboxPromise
 
   // inject the manifest
   const buildResult = await injectManifest(injectManifestOptions)
   // log workbox result
   logWorkboxResult(
+    version,
     options.throwMaximumFileSizeToCacheInBytes,
     'injectManifest',
     buildResult,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR includes:
- use `readFileSync`  to load version
- add `./package.json` to package exports
- update `debug`  to `4.3.6`
- update `@vite-pwa/assets-generator` to `0.2.6`
- load `workbox` when using `injectManifest` strategy only when there is injection point
- change `maximumFileSizeToCacheInBytes` error message, check screenshots below

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->
closes #749

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
![imagen](https://github.com/user-attachments/assets/54f19e98-ebf3-4015-a8b6-714ff2e50173)
_generateSW strategy error_

![imagen](https://github.com/user-attachments/assets/d2f674d3-e05f-41be-b54a-19cfad360354)
_injectManifest strategy error_

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
