### PR TITLE
fix!: Rollup build XSS vulnerability (CVE-2024-43788)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^0.2.6",
-    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
+    "vite": "^4.2.0 || ^5.0.0",
     "workbox-build": "^7.1.0",
     "workbox-window": "^7.1.0"
   },
@@ -145,7 +145,6 @@
     "prompts": "^2.4.2",
     "publint": "^0.2.5",
     "react": "^18.2.0",
-    "rollup": "^4.4.1",
     "solid-js": "^1.8.5",
     "svelte": "^4.2.5",
     "tsup": "^7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      rollup:
-        specifier: ^4.4.1
-        version: 4.4.1
       solid-js:
         specifier: ^1.8.5
         version: 1.8.5

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-import type { BuildOptions, InlineConfig, Plugin, ResolvedConfig, UserConfig } from 'vite'
+import type { BuildOptions, InlineConfig, Plugin, ResolvedConfig, Rollup, UserConfig } from 'vite'
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
-import type { OutputBundle, RollupOptions } from 'rollup'
 import type { BuiltInPreset, Preset } from '@vite-pwa/assets-generator/config'
 import type { HtmlLinkPreset } from '@vite-pwa/assets-generator/api'
 import type { PWAAssetsGenerator } from './pwa-assets/types'
@@ -78,13 +77,13 @@ export type CustomInjectManifestOptions = InjectManifestOptions & {
    * **WARN**: this option is for advanced usage, beware, you can break your application build.
    */
   buildPlugins?: {
-    rollup?: RollupOptions['plugins']
+    rollup?: Rollup.RollupOptions['plugins']
     vite?: UserConfig['plugins']
   }
   /**
    * Since `v0.15.0` you can add custom Rollup options to build your service worker: we expose the same configuration to build a worker using Vite.
    */
-  rollupOptions?: Omit<RollupOptions, 'plugins' | 'output'>
+  rollupOptions?: Omit<Rollup.RollupOptions, 'plugins' | 'output'>
 
   /**
    * Environment options.
@@ -407,7 +406,7 @@ export interface VitePWAOptions {
 export interface ResolvedServiceWorkerOptions {
   format: 'es' | 'iife'
   plugins?: Plugin[]
-  rollupOptions: RollupOptions
+  rollupOptions: Rollup.RollupOptions
 }
 
 export interface ResolvedVitePWAOptions extends Required<Omit<VitePWAOptions, 'pwaAssets' | 'showMaximumFileSizeToCacheInBytesWarning'>> {
@@ -706,7 +705,7 @@ export interface VitePluginPWAAPI {
   /*
    * Explicitly generate the manifests.
    */
-  generateBundle(bundle?: OutputBundle): OutputBundle | undefined
+  generateBundle(bundle?: Rollup.OutputBundle): Rollup.OutputBundle | undefined
   /*
    * Explicitly generate the PWA services worker.
    */


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR removes Rollup from dependencies, using the exported from Vite.

This is breaking since we need Vite `4.2.0+` to re-use exported Rollup types included in this PR https://github.com/vitejs/vite/pull/12316 (included in Vite `4.2.0-beta.2 (2023-03-13)`).

This PR doesn't solve [CVE-2024-43788](https://github.com/webpack/webpack/security/advisories/GHSA-4vvj-4cpr-p986) since `workbox-build` and Vite have the same problem as pointed in the linked issue, the consumer should use `overrides`, `resolutions` or `pnpm.overrides` to override Rollup version.

Once Vite and `workbox-build` fix the vulnerability the PWA plugin should be ready.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->
closes #758

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
