### PR TITLE
feat(html): add head when missing from entry point

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -1,3 +1,4 @@
+import { yellow } from 'kolorist'
 import {
   DEV_PWA_ASSETS_NAME,
   DEV_READY_NAME,
@@ -25,20 +26,36 @@ navigator.serviceWorker.register('${path}', { scope: '${options.scope}' })
 }`.replace(/\n/g, '')
 }
 
+export function checkForHtmlHead(html: string) {
+  if (!html.includes('</head>')) {
+    if (!html.includes('<body>')) {
+      console.warn([
+        '',
+        yellow('PWA WARNING:'),
+        '</head> and <body> not found in the html, the service worker and web manifest will not be injected.',
+      ].join('\n'))
+      return html
+    }
+    return html.replace('<body>', `<head>\n</head>\n<body>`)
+  }
+
+  return html
+}
+
 export function injectServiceWorker(html: string, options: ResolvedVitePWAOptions, dev: boolean) {
   const manifest = generateWebManifest(options, dev)
 
   if (!dev) {
     const script = generateRegisterSW(options, dev)
     if (script) {
-      return html.replace(
+      return checkForHtmlHead(html).replace(
         '</head>',
         `${manifest}${script}</head>`,
       )
     }
   }
 
-  return html.replace(
+  return checkForHtmlHead(html).replace(
     '</head>',
     `${manifest}</head>`,
   )

--- a/src/html.ts
+++ b/src/html.ts
@@ -32,9 +32,16 @@ export function checkForHtmlHead(html: string) {
       console.warn([
         '',
         yellow('PWA WARNING:'),
-        '</head> and <body> not found in the html, the service worker and web manifest will not be injected.',
+        '</head> and <body> tags not found in the html, the service worker and web manifest will not be injected.',
       ].join('\n'))
       return html
+    }
+    else {
+      console.warn([
+        '',
+        yellow('PWA WARNING:'),
+        '</head> not found in the html, adding it to the html tag: add empty <head></head> to your html to remove this warning.',
+      ].join('\n'))
     }
     return html.replace('<body>', `<head>\n</head>\n<body>`)
   }

--- a/src/pwa-assets/html.ts
+++ b/src/pwa-assets/html.ts
@@ -1,5 +1,6 @@
 import { generateHtmlMarkup } from '@vite-pwa/assets-generator/api/generate-html-markup'
 import type { PWAPluginContext } from '../context'
+import { checkForHtmlHead } from '../html'
 import type { AssetsGeneratorContext, PWAHtmlAssets } from './types'
 import { mapLink } from './utils'
 
@@ -11,7 +12,7 @@ export function transformIndexHtml(
   if (assetsGeneratorContext.injectThemeColor) {
     const manifest = ctx.options.manifest
     if (manifest && 'theme_color' in manifest && manifest.theme_color) {
-      html = html.replace(
+      html = checkForHtmlHead(html).replace(
         '</head>',
           `\n<meta name="theme-color" content="${manifest.theme_color}"></head>`,
       )
@@ -21,7 +22,7 @@ export function transformIndexHtml(
   if (assetsGeneratorContext.includeHtmlHeadLinks) {
     const link = generateHtmlMarkup(assetsGeneratorContext.assetsInstructions)
     if (link.length)
-      html = html.replace('</head>', `\n${link.join('\n')}</head>`)
+      html = checkForHtmlHead(html).replace('</head>', `\n${link.join('\n')}</head>`)
   }
 
   return html


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
When there is no `head` in the html entry point, the sw and the web manifest may not be register: this PR checks for `</head>`  and `<body>` to add the head when required, showing a warning when missing both.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->
resolves #782

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
