### PR TITLE
chore: Remove dead code

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -98,10 +98,7 @@ export function registerSW(options: RegisterSWOptions = {}) {
                   !onNeedRefreshCalled && onOfflineReady?.()
               }
               else {
-                if (event.isExternal)
-                  window.location.reload()
-                else
-                  !onNeedRefreshCalled && onOfflineReady?.()
+                !onNeedRefreshCalled && onOfflineReady?.()
               }
             }
             else if (!event.isUpdate) {


### PR DESCRIPTION
### Description

At given point `event.isExternal` has already been evaluated to be `undefined`

https://github.com/vite-pwa/vite-plugin-pwa/blob/bee73adb56f3f08434981c022ecd5657d040ed55/src/client/build/register.ts#L94

so it's value cannot be truthy.

### Linked Issues

none

### Additional Context

I'm just trying to understand how the client-side logic works