### PR TITLE
chore: remove listener for non-existing `externalwaiting` event

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -111,8 +111,6 @@ export function registerSW(options: RegisterSWOptions = {}) {
           // Add an event listener to detect when the registered
           // service worker has installed but is waiting to activate.
           wb.addEventListener('waiting', showSkipWaitingPrompt)
-          // @ts-expect-error event listener provided by workbox-window
-          wb.addEventListener('externalwaiting', showSkipWaitingPrompt)
         }
       }
 


### PR DESCRIPTION
### Description

Event has been removed in workbox 6: https://developer.chrome.com/docs/workbox/migration/migrate-from-v5
Context: https://github.com/googlechrome/workbox/issues/2786

### Linked Issues

none

### Additional Context

Continuation of https://github.com/vite-pwa/vite-plugin-pwa/commit/c3a0710ee119995cb08d975c9f28f4e9f5df9ecb
