### PR TITLE
Fix: Do not await workbox-window messageSkipWaiting

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -26,12 +26,12 @@ export function registerSW(options: RegisterSWOptions = {}) {
 
   let wb: import('workbox-window').Workbox | undefined
   let registerPromise: Promise<void>
-  let sendSkipWaitingMessage: () => Promise<void> | undefined
+  let sendSkipWaitingMessage: () => void | undefined
 
   const updateServiceWorker = async (_reloadPage = true) => {
     await registerPromise
     if (!auto) {
-      await sendSkipWaitingMessage?.()
+      sendSkipWaitingMessage?.()
     }
   }
 
@@ -48,12 +48,12 @@ export function registerSW(options: RegisterSWOptions = {}) {
       if (!wb)
         return
 
-      sendSkipWaitingMessage = async () => {
+      sendSkipWaitingMessage = () => {
         // Send a message to the waiting service worker,
         // instructing it to activate.
         // Note: for this to work, you have to add a message
         // listener in your service worker. See below.
-        await wb?.messageSkipWaiting()
+        wb?.messageSkipWaiting()
       }
       if (!autoDestroy) {
         if (auto) {


### PR DESCRIPTION
### Description

The `Workbox#messageSkipWaiting` method is not asynchronous (never was), therefore there is no need to await it

### Linked Issues

None

### Additional Context

See https://github.com/GoogleChrome/workbox/blob/v7.3.0/packages/workbox-window/src/Workbox.ts#L325