### PR TITLE
fix: return async function from `registerSW` in dev mode

### DIFF
--- a/src/client/dev/register.ts
+++ b/src/client/dev/register.ts
@@ -3,5 +3,5 @@ import type { RegisterSWOptions } from '../type'
 export type { RegisterSWOptions }
 
 export function registerSW(_options: RegisterSWOptions = {}) {
-  return (_reloadPage = true) => {}
+  return async (_reloadPage = true) => {}
 }


### PR DESCRIPTION
### Description

The signature for `registerSW` function should be same for both *production* and *development*:

```ts
function registerSW(options: RegisterOptions = {}): (_reloadPage?: boolean) => Promise<void>
```

### Linked Issues

None

### Additional Context

When trying to update service worker in *development*, following code throws an error:

```ts
import { registerSW } from 'virtual:pwa-register'

const updateServiceWorker = registerSW()

updateServiceWorker.then(() => {})
// Uncaught TypeError: Cannot read properties of undefined (reading 'then')
```
