### PR TITLE
feat: add separate type definitions for `updateServiceWorker() and updateServiceWorker(true)

### DIFF
--- a/preact.d.ts
+++ b/preact.d.ts
@@ -9,11 +9,15 @@ declare module 'virtual:pwa-register/preact' {
   export function useRegisterSW(options?: RegisterSWOptions): {
     needRefresh: [boolean, StateUpdater<boolean>]
     offlineReady: [boolean, StateUpdater<boolean>]
-    /**
-     * Reloads the current window to allow the service worker take the control.
-     *
-     * @param reloadPage From version 0.13.2+ this param is not used anymore.
-     */
-    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+    updateServiceWorker: {
+      /**
+       * Reloads the current window to allow the service worker take the control.
+       */
+      (): Promise<void>
+      /**
+       * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+       */
+      (reloadPage: boolean): Promise<void>
+    }
   }
 }

--- a/react.d.ts
+++ b/react.d.ts
@@ -9,11 +9,15 @@ declare module 'virtual:pwa-register/react' {
   export function useRegisterSW(options?: RegisterSWOptions): {
     needRefresh: [boolean, Dispatch<SetStateAction<boolean>>]
     offlineReady: [boolean, Dispatch<SetStateAction<boolean>>]
-    /**
-     * Reloads the current window to allow the service worker take the control.
-     *
-     * @param reloadPage From version 0.13.2+ this param is not used anymore.
-     */
-    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+    updateServiceWorker: {
+      /**
+       * Reloads the current window to allow the service worker take the control.
+       */
+      (): Promise<void>
+      /**
+       * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+       */
+      (reloadPage: boolean): Promise<void>
+    }
   }
 }

--- a/solid.d.ts
+++ b/solid.d.ts
@@ -9,11 +9,15 @@ declare module 'virtual:pwa-register/solid' {
   export function useRegisterSW(options?: RegisterSWOptions): {
     needRefresh: [Accessor<boolean>, Setter<boolean>]
     offlineReady: [Accessor<boolean>, Setter<boolean>]
-    /**
-     * Reloads the current window to allow the service worker take the control.
-     *
-     * @param reloadPage From version 0.13.2+ this param is not used anymore.
-     */
-    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+    updateServiceWorker: {
+      /**
+       * Reloads the current window to allow the service worker take the control.
+       */
+      (): Promise<void>
+      /**
+       * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+       */
+      (reloadPage: boolean): Promise<void>
+    }
   }
 }

--- a/svelte.d.ts
+++ b/svelte.d.ts
@@ -9,11 +9,15 @@ declare module 'virtual:pwa-register/svelte' {
   export function useRegisterSW(options?: RegisterSWOptions): {
     needRefresh: Writable<boolean>
     offlineReady: Writable<boolean>
-    /**
-     * Reloads the current window to allow the service worker take the control.
-     *
-     * @param reloadPage From version 0.13.2+ this param is not used anymore.
-     */
-    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+    updateServiceWorker: {
+      /**
+       * Reloads the current window to allow the service worker take the control.
+       */
+      (): Promise<void>
+      /**
+       * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+       */
+      (reloadPage: boolean): Promise<void>
+    }
   }
 }

--- a/vanillajs.d.ts
+++ b/vanillajs.d.ts
@@ -7,7 +7,13 @@ declare module 'virtual:pwa-register' {
    * Registers the service worker returning a callback to reload the current page when an update is found.
    *
    * @param options the options to register the service worker.
-   * @return (reloadPage?: boolean) => Promise<void> From version 0.13.2+ `reloadPage` param is not used anymore.
+   * @return (reloadPage?: boolean) => Promise<void> From version 0.14.0+ `reloadPage` param is not used anymore.
    */
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>
+  export function registerSW(options?: RegisterSWOptions): {
+    (): Promise<void>
+    /**
+     * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+     */
+    (reloadPage: boolean): Promise<void>
+  }
 }

--- a/vue.d.ts
+++ b/vue.d.ts
@@ -9,11 +9,15 @@ declare module 'virtual:pwa-register/vue' {
   export function useRegisterSW(options?: RegisterSWOptions): {
     needRefresh: Ref<boolean>
     offlineReady: Ref<boolean>
-    /**
-     * Reloads the current window to allow the service worker take the control.
-     *
-     * @param reloadPage From version 0.13.2+ this param is not used anymore.
-     */
-    updateServiceWorker: (reloadPage?: boolean) => Promise<void>
+    updateServiceWorker: {
+      /**
+       * Reloads the current window to allow the service worker take the control.
+       */
+      (): Promise<void>
+      /**
+       * @deprecated The `reloadPage` param is not used anymore sice 0.14.0
+       */
+      (reloadPage: boolean): Promise<void>
+    }
   }
 }


### PR DESCRIPTION
### Description

The `reloadPage` parameter of `updateServiceWorker` has been deprecated in https://github.com/vite-pwa/vite-plugin-pwa/compare/v0.13.3...v0.14.0 and has no effect.

This adds the `@deprecated` jsdoc tag which shows in VScode

### Linked Issues

none

### Additional Context

To test, open [examples/preact-router/src/ReloadPrompt.tsx#L53](https://github.com/vite-pwa/vite-plugin-pwa/blob/v0.21.1/examples/preact-router/src/ReloadPrompt.tsx#L53) in VSCode and point over `updateServiceWorker(true)`:

![image](https://github.com/user-attachments/assets/b9946b74-24bd-4120-aacc-e63e05d1e6b2)