### PR TITLE
fix: remove usage of deprecated `reloadPage` param in examples

### DIFF
--- a/examples/preact-router/src/ReloadPrompt.tsx
+++ b/examples/preact-router/src/ReloadPrompt.tsx
@@ -50,7 +50,7 @@ function ReloadPrompt() {
               ? <span>App ready to work offline</span>
               : <span>New content available, click on reload button to update.</span>}
           </div>
-          { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker(true)}>Reload</button> }
+          { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker()}>Reload</button> }
           <button className="ReloadPrompt-toast-button" onClick={() => close()}>Close</button>
         </div>
       )}

--- a/examples/react-router/src/ReloadPrompt.tsx
+++ b/examples/react-router/src/ReloadPrompt.tsx
@@ -51,7 +51,7 @@ function ReloadPrompt() {
               ? <span>App ready to work offline</span>
               : <span>New content available, click on reload button to update.</span>}
           </div>
-          { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker(true)}>Reload</button> }
+          { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker()}>Reload</button> }
           <button className="ReloadPrompt-toast-button" onClick={() => close()}>Close</button>
         </div>
       )}

--- a/examples/solid-router/src/ReloadPrompt.tsx
+++ b/examples/solid-router/src/ReloadPrompt.tsx
@@ -51,7 +51,7 @@ const ReloadPrompt: Component = () => {
             </Show>
           </div>
           <Show when={needRefresh()}>
-            <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button>
+            <button class={styles.ToastButton} onClick={() => updateServiceWorker()}>Reload</button>
           </Show>
           <button class={styles.ToastButton} onClick={() => close()}>Close</button>
         </div>

--- a/examples/svelte-routify/src/lib/ReloadPrompt.svelte
+++ b/examples/svelte-routify/src/lib/ReloadPrompt.svelte
@@ -59,7 +59,7 @@
       {/if}
     </div>
     {#if $needRefresh}
-      <button on:click={() => updateServiceWorker(true)}>
+      <button on:click={() => updateServiceWorker()}>
         Reload
       </button>
     {/if}

--- a/examples/sveltekit-pwa/src/lib/components/ReloadPrompt.svelte
+++ b/examples/sveltekit-pwa/src/lib/components/ReloadPrompt.svelte
@@ -45,7 +45,7 @@
 			{/if}
 		</div>
 		{#if $needRefresh}
-			<button on:click={() => updateServiceWorker(true)}>
+			<button on:click={() => updateServiceWorker()}>
 				Reload
 			</button>
 		{/if}


### PR DESCRIPTION
### Description

The `reloadPage` parameter of `updateServiceWorker` has been deprecated in https://github.com/vite-pwa/vite-plugin-pwa/compare/v0.13.3...v0.14.0 and has no effect, but is still present in some of the examples

### Linked Issues

none

### Additional Context

none