### PR TITLE
Allow only generating webmanifest (without service worker) as strategy

### DIFF
--- a/docs/guide/service-worker-strategies-and-behaviors.md
+++ b/docs/guide/service-worker-strategies-and-behaviors.md
@@ -8,9 +8,10 @@ A service worker strategy is related to how the `vite-plugin-pwa` plugin will ge
 
 ## Service Worker Strategies
 
-As we mention in [Configuring vite-plugin-pwa](/guide/#configuring-vite-plugin-pwa) section, `vite-plugin-pwa` plugin will use `workbox-build` node library to generate your service worker. There are 2 available strategies, `generateSW` and `injectManifest`:
+As we mention in [Configuring vite-plugin-pwa](/guide/#configuring-vite-plugin-pwa) section, `vite-plugin-pwa` plugin will use `workbox-build` node library to generate your service worker. There are 3 available strategies, `generateSW`, `injectManifest` and `webManifestOnly`:
 - `generateSW`: the `vite-plugin-pwa` will generate the service worker for you, you don't need to write the code for the service worker
 - `injectManifest`: the `vite-plugin-pwa` plugin will compile your custom service worker and inject its precache manifest
+- `webManifestOnly`: the `vite-plugin-pwa` plugin will only generate a webmanifest file and no service worker
 
 To configure the service worker strategy, use the `strategies`' plugin option with `generateSW` (**default strategy**) or `injectManifest` value.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,10 +18,19 @@ export async function _generateSW({ options, version, viteConfig }: PWAPluginCon
   if (options.disable)
     return
 
-  if (options.strategies === 'injectManifest')
-    await generateInjectManifest(version, options, viteConfig)
-  else
-    await generateServiceWorker(version, options, viteConfig)
+  switch (options.strategies) {
+    case 'generateSW':
+      await generateServiceWorker(version, options, viteConfig)
+      break
+    case 'injectManifest':
+      await generateInjectManifest(version, options, viteConfig)
+      break
+    case 'webManifestOnly':
+      // do nothing
+      break
+    default:
+      throw new Error(`Unknown PWA strategy '${options.strategies}'`)
+  }
 }
 
 export function _generateBundle(ctx: PWAPluginContext, bundle?: OutputBundle) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,10 +18,19 @@ export async function _generateSW({ options, version, viteConfig }: PWAPluginCon
   if (options.disable)
     return
 
-  if (options.strategies === 'injectManifest')
-    await generateInjectManifest(version, options, viteConfig)
-  else
-    await generateServiceWorker(version, options, viteConfig)
+  switch (options.strategies) {
+    case 'generateSW':
+      await generateServiceWorker(version, options, viteConfig)
+      break
+    case 'injectManifest':
+      await generateInjectManifest(version, options, viteConfig)
+      break
+    case 'webManifestOnly':
+      // do nothing
+      break
+    default:
+      throw new Error(`Unknown PWA strategy '${options.strategies}'`)
+  }
 }
 
 export function _generateBundle(ctx: PWAPluginContext, bundle?: OutputBundle, pluginCtx?: PluginContext) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,7 +272,7 @@ export interface VitePWAOptions {
   /**
    * @default 'generateSW'
    */
-  strategies?: 'generateSW' | 'injectManifest'
+  strategies?: 'generateSW' | 'injectManifest' | 'webManifestOnly'
   /**
    * The scope to register the Service Worker
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,7 +270,7 @@ export interface VitePWAOptions {
   /**
    * @default 'generateSW'
    */
-  strategies?: 'generateSW' | 'injectManifest'
+  strategies?: 'generateSW' | 'injectManifest' | 'webManifestOnly'
   /**
    * The scope to register the Service Worker
    *


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

This PR aims to add a very simple `webManifestOnly` strategy to the plugin, which does not generate a service worker at all. This is useful for very minimal setups, which want to generate just a webmanifest file (possibly with additional assets generated through the assets-generator plugin).

### Linked Issues

N/A

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
