### PR TITLE
chore: remove usage of deprecated `reloadPage` param in examples

### DIFF
--- a/examples/preact-router/src/ReloadPrompt.tsx
+++ b/examples/preact-router/src/ReloadPrompt.tsx
@@ -50,7 +50,7 @@ function ReloadPrompt() {
                 ? <span>App ready to work offline</span>
                 : <span>New content available, click on reload button to update.</span>}
             </div>
-            { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker(true)}>Reload</button> }
+            { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker()}>Reload</button> }
             <button className="ReloadPrompt-toast-button" onClick={() => close()}>Close</button>
           </div>
         )}

--- a/examples/react-router/src/ReloadPrompt.tsx
+++ b/examples/react-router/src/ReloadPrompt.tsx
@@ -51,7 +51,7 @@ function ReloadPrompt() {
                 ? <span>App ready to work offline</span>
                 : <span>New content available, click on reload button to update.</span>}
             </div>
-            { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker(true)}>Reload</button> }
+            { needRefresh && <button className="ReloadPrompt-toast-button" onClick={() => updateServiceWorker()}>Reload</button> }
             <button className="ReloadPrompt-toast-button" onClick={() => close()}>Close</button>
           </div>
         )}

--- a/examples/solid-router/src/ReloadPrompt.tsx
+++ b/examples/solid-router/src/ReloadPrompt.tsx
@@ -51,7 +51,7 @@ const ReloadPrompt: Component = () => {
             </Show>
           </div>
           <Show when={needRefresh()}>
-            <button class={styles.ToastButton} onClick={() => updateServiceWorker(true)}>Reload</button>
+            <button class={styles.ToastButton} onClick={() => updateServiceWorker()}>Reload</button>
           </Show>
           <button class={styles.ToastButton} onClick={() => close()}>Close</button>
         </div>

--- a/examples/svelte-routify/src/lib/ReloadPrompt.svelte
+++ b/examples/svelte-routify/src/lib/ReloadPrompt.svelte
@@ -59,7 +59,7 @@
       {/if}
     </div>
     {#if $needRefresh}
-      <button on:click={() => updateServiceWorker(true)}>
+      <button on:click={() => updateServiceWorker()}>
         Reload
       </button>
     {/if}

--- a/examples/sveltekit-pwa/src/lib/components/ReloadPrompt.svelte
+++ b/examples/sveltekit-pwa/src/lib/components/ReloadPrompt.svelte
@@ -45,7 +45,7 @@
 			{/if}
 		</div>
 		{#if $needRefresh}
-			<button on:click={() => updateServiceWorker(true)}>
+			<button on:click={() => updateServiceWorker()}>
 				Reload
 			</button>
 		{/if}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
supersedes #803

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
