### PR TITLE
fix: avoid assigning to bundle object

### DIFF
--- a/src/plugins/build.ts
+++ b/src/plugins/build.ts
@@ -35,7 +35,7 @@ export function BuildPlugin(ctx: PWAPluginContext) {
       if (pwaAssetsGenerator)
         pwaAssetsGenerator.injectManifestIcons()
 
-      return _generateBundle(ctx, bundle)
+      return _generateBundle(ctx, bundle, this)
     },
     closeBundle: {
       sequential: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { HtmlLinkPreset } from '@vite-pwa/assets-generator/api'
 import type { BuiltInPreset, Preset } from '@vite-pwa/assets-generator/config'
-import type { OutputBundle, RollupOptions } from 'rollup'
+import type { OutputBundle, PluginContext, RollupOptions } from 'rollup'
 import type { BuildOptions, InlineConfig, Plugin, ResolvedConfig, UserConfig } from 'vite'
 import type { GenerateSWOptions, InjectManifestOptions, ManifestEntry } from 'workbox-build'
 import type { PWAAssetsGenerator } from './pwa-assets/types'
@@ -706,7 +706,7 @@ export interface VitePluginPWAAPI {
   /*
    * Explicitly generate the manifests.
    */
-  generateBundle: (bundle?: OutputBundle) => OutputBundle | undefined
+  generateBundle: (bundle?: OutputBundle, pluginCtx?: PluginContext) => OutputBundle | undefined
   /*
    * Explicitly generate the PWA services worker.
    */


### PR DESCRIPTION
### Description

[Assigning to `bundle` object is discouraged by rollup](https://rollupjs.org/plugin-development/#generatebundle:~:text=DANGER,this.emitFile.) and is not supported by rolldown.

This PR changes the code using assignment to use `this.emitFile` instead. This would make vite-plugin-pwa work with Rolldown powered Vite.

If the plugin context is not passed to `api.generateBundle`, it will still use the previous method for backward compat.

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
