### PR TITLE
docs: mention proper default for navigateFallback

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -745,6 +745,8 @@ export interface DevOptions {
    * configure here the corresponding `url`, for example `navigateFallback: 'index.html'`.
    *
    * **WARNING**: this option will only be used when using `injectManifest` strategy.
+   *
+   * @default 'index.html'
    */
   navigateFallback?: string
 


### PR DESCRIPTION
In typescript the default value for `navigateFallback` is documented as `null` because it is not mentioned. In [options.ts](https://github.com/vite-pwa/vite-plugin-pwa/blob/92eca1b6ce047071b35e9e9c7ed2825745a7a269/src/options.ts#L94) the default `navigateFallback: 'index.html'` is set. At the same tame for the `navigateFallbackAllowlist` or `-Denylist` both relate to the `navigateFallback`.

I suggest to document the proper default value.
