### PR TITLE
fix: add Vite 7.0.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^1.0.0",
-    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "workbox-build": "^7.3.0",
     "workbox-window": "^7.3.0"
   },


### PR DESCRIPTION
Description

This PR adds Vite 7.0.0 support by updating the vite peer dependency range.
It allows users of Vite 7.x to use this plugin without peer dependency warnings.
Linked Issues

N/A
Additional Context

No additional changes or tests were necessary, as this is a peer dependency range update only.
Please let me know if you'd like me to include documentation updates or further compatibility checks.