### PR TITLE
fix: add origin to scope_extensions to comply with the spec and get rid of warning

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -176,6 +176,15 @@ export async function resolveOptions(ctx: PWAPluginContext): Promise<ResolvedVit
         }
       })
     }
+
+    if (manifest.scope_extensions) {
+      manifest.scope_extensions = manifest.scope_extensions.map((scopeExtension) => {
+        return {
+          origin: scopeExtension.origin,
+          type: scopeExtension.type ?? 'origin',
+        }
+      })
+    }
   }
 
   const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -641,8 +641,8 @@ export interface ManifestOptions {
   scope_extensions: {
     origin: string
     /**
-      * @default 'origin'
-      */
+     * @default 'origin'
+     */
     type?: StringLiteralUnion<ScopeExtensionsType> | ScopeExtensionsType
   }[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,10 +458,7 @@ interface Nothing {}
  */
 export type StringLiteralUnion<T extends U, U = string> = T | (U & Nothing)
 
-/**
- * @default 'origin'
- * @see https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope_extensions
- */
+
 export type ScopeExtensionsType = 'origin'
 
 /**
@@ -635,12 +632,17 @@ export interface ManifestOptions {
   edge_side_panel?: {
     preferred_width?: number
   }
+
   /**
    * @see https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md
+   * @see https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope_extensions
    * @default []
    */
   scope_extensions: {
     origin: string
+    /**
+      * @default 'origin'
+      */
     type?: StringLiteralUnion<ScopeExtensionsType> | ScopeExtensionsType
   }[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -459,6 +459,12 @@ interface Nothing {}
 export type StringLiteralUnion<T extends U, U = string> = T | (U & Nothing)
 
 /**
+ * @default 'origin'
+ * @see https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope_extensions
+ */
+export type ScopeExtensionsType = 'origin'
+
+/**
  * @see https://w3c.github.io/manifest/#manifest-image-resources
  */
 export interface IconResource {
@@ -635,7 +641,7 @@ export interface ManifestOptions {
    */
   scope_extensions: {
     origin: string
-    type?: 'origin'
+    type?: StringLiteralUnion<ScopeExtensionsType> | ScopeExtensionsType
   }[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,7 +458,6 @@ interface Nothing {}
  */
 export type StringLiteralUnion<T extends U, U = string> = T | (U & Nothing)
 
-
 export type ScopeExtensionsType = 'origin'
 
 /**
@@ -643,7 +642,7 @@ export interface ManifestOptions {
     /**
      * @default 'origin'
      */
-    type?: StringLiteralUnion<ScopeExtensionsType> | ScopeExtensionsType
+    type?: StringLiteralUnion<ScopeExtensionsType>
   }[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,6 +635,7 @@ export interface ManifestOptions {
    */
   scope_extensions: {
     origin: string
+    type?: 'origin'
   }[]
 }
 


### PR DESCRIPTION
### Description

Warning in chrome 139.0.7258.66

`manifest.webmanifest:1 Manifest: scope_extensions entry ignored, required properties 'type' and 'origin' are missing.`

### Linked Issues

Fixes https://github.com/vite-pwa/vite-plugin-pwa/issues/879

### Additional Context

I made the property optional since 'origin' is the only allowed type and there shouldn't be a breaking type change for such a minor issue. Therefore, I don't yet see the value in documenting it. If you'd like me to update some docs, let me know!  


