### PR TITLE
fix: resolveDevDistFolder to use outDir

### DIFF
--- a/src/plugins/dev.ts
+++ b/src/plugins/dev.ts
@@ -245,7 +245,7 @@ export function DevPlugin(ctx: PWAPluginContext) {
 async function resolveDevDistFolder(options: ResolvedVitePWAOptions, viteConfig: ResolvedConfig) {
   return options.devOptions.resolveTempFolder
     ? await options.devOptions.resolveTempFolder()
-    : resolve(viteConfig.outDir, 'dev-dist')
+    : resolve(options.outDir, 'dev-dist')
 }
 
 async function createDevRegisterSW(options: ResolvedVitePWAOptions, viteConfig: ResolvedConfig) {


### PR DESCRIPTION
### Description

When using the generateSW function in dev mode, it seems the `dev-dist` folder resolves to the root, which in my react-router v7 project for [ZFGC.com](https://github.com/ZeldaFanGameCentral/ZFGBB-React) makes the dev sw stop working(I also have my outDir set to dist/client). This change modifies the function to use the configured outDir. 

### Linked Issues

N/A

### Additional Context

This seems to be an issue if you set the outDir

P.S. Thank you for this amazing plugin, by the way! I've used it on both Nuxt and React based projects with no issues! \o/

---
