### PR TITLE
chore: use `"moduleResolution": "bundler"`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "lib": ["ESNext", "DOM", "WebWorker"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
### Description

Vite 8 removed `types` field (https://github.com/vitejs/vite/pull/21194). It is only used when using `"moduleResolution": "node"`. `"moduleResolution": "node"` is deprecated.

This PR will fix the following ecosystem-ci error
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/21385310007/job/61560517152#step:7:878

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/vite-plugin-pwa/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-plugin-pwa!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
