### PR TITLE
feat(client): add onNeedReload callback

### DIFF
--- a/docs/frameworks/index.md
+++ b/docs/frameworks/index.md
@@ -30,6 +30,7 @@ You can find all the `vite-plugin-pwa` virtual modules declarations in the follo
 declare module 'virtual:pwa-register' {
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/frameworks/preact.md
+++ b/docs/frameworks/preact.md
@@ -23,6 +23,7 @@ declare module 'virtual:pwa-register/preact' {
 
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/frameworks/react.md
+++ b/docs/frameworks/react.md
@@ -23,6 +23,7 @@ declare module 'virtual:pwa-register/react' {
 
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/frameworks/solidjs.md
+++ b/docs/frameworks/solidjs.md
@@ -23,6 +23,7 @@ declare module 'virtual:pwa-register/solid' {
 
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -23,6 +23,7 @@ declare module 'virtual:pwa-register/svelte' {
 
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -21,6 +21,7 @@ declare module 'virtual:pwa-register/vue' {
 
   export interface RegisterSWOptions {
     immediate?: boolean
+    onNeedReload?: () => void
     onNeedRefresh?: () => void
     onOfflineReady?: () => void
     /**

--- a/docs/guide/auto-update.md
+++ b/docs/guide/auto-update.md
@@ -6,6 +6,8 @@ title: Automatic reload | Guide
 
 With this behavior, once the browser detects a new version of your application, then, it will update the caches and will reload any browser windows/tabs with the application opened automatically to take the control.
 
+If you need full control over *when* the app reloads (for example, to defer the reload until the next SPA navigation), provide an `onNeedReload` callback when registering the service worker.
+
 The disadvantage of using this behavior is that the user can lose data in any browser windows/tabs in which the application is open and is filling in a form.
 
 If your application has forms, we recommend you to change the behavior to use default `prompt` option to allow the user decide when to update the content of the application.
@@ -51,6 +53,10 @@ import { registerSW } from 'virtual:pwa-register'
 
 const updateSW = registerSW({
   onOfflineReady() {},
+  onNeedReload() {
+    // called when the updated service worker takes control.
+    // default behavior (when omitted) is: window.location.reload()
+  },
 })
 ```
 
@@ -61,4 +67,3 @@ When the user clicks the `OK` button, just hide the prompt shown on `onOfflineRe
 ### SSR/SSG
 
 <SsrSsg />
-

--- a/docs/guide/prompt-for-update.md
+++ b/docs/guide/prompt-for-update.md
@@ -29,6 +29,10 @@ import { registerSW } from 'virtual:pwa-register'
 const updateSW = registerSW({
   onNeedRefresh() {},
   onOfflineReady() {},
+  onNeedReload() {
+    // called after you call updateSW(), when the updated SW takes control.
+    // use it to delay a hard reload and coordinate with your router.
+  },
 })
 ```
 
@@ -36,11 +40,10 @@ You will need to:
 - show a prompt to the user with refresh and cancel buttons inside `onNeedRefresh` method.
 - show a ready to work offline message to the user with an OK button inside `onOfflineReady` method.
 
-When the user clicks the "refresh" button when `onNeedRefresh` called, then call `updateSW()` function; the page will reload and the up-to-date content will be served.
+When the user clicks the "refresh" button when `onNeedRefresh` called, then call `updateSW()` function; by default the page will reload and the up-to-date content will be served. If you provide `onNeedReload`, the plugin will call it instead of reloading the page.
 
 In any case, when the user clicks the `Cancel` or `OK` buttons in case `onNeedRefresh` or `onOfflineReady` respectively, close the corresponding showed prompt.
 
 ### SSR/SSG
 
 <SsrSsg />
-

--- a/src/client/build/preact.ts
+++ b/src/client/build/preact.ts
@@ -7,6 +7,7 @@ export type { RegisterSWOptions }
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
     immediate = true,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -20,6 +21,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   const [updateServiceWorker] = useState(() => {
     return registerSW({
       immediate,
+      onNeedReload,
       onOfflineReady() {
         setOfflineReady(true)
         onOfflineReady?.()

--- a/src/client/build/react.ts
+++ b/src/client/build/react.ts
@@ -7,6 +7,7 @@ export type { RegisterSWOptions }
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
     immediate = true,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -20,6 +21,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
   const [updateServiceWorker] = useState(() => {
     return registerSW({
       immediate,
+      onNeedReload,
       onOfflineReady() {
         setOfflineReady(true)
         onOfflineReady?.()

--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -17,6 +17,7 @@ export type { RegisterSWOptions }
 export function registerSW(options: RegisterSWOptions = {}) {
   const {
     immediate = false,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -58,8 +59,12 @@ export function registerSW(options: RegisterSWOptions = {}) {
       if (!autoDestroy) {
         if (auto) {
           wb.addEventListener('activated', (event) => {
-            if (event.isUpdate || event.isExternal)
-              window.location.reload()
+            if (event.isUpdate || event.isExternal) {
+              if (onNeedReload)
+                onNeedReload()
+              else
+                window.location.reload()
+            }
           })
           wb.addEventListener('installed', (event) => {
             if (!event.isUpdate) {
@@ -83,8 +88,12 @@ export function registerSW(options: RegisterSWOptions = {}) {
             // that will reload the page as soon as the previously waiting
             // service worker has taken control.
             wb?.addEventListener('controlling', (event) => {
-              if (event.isUpdate)
-                window.location.reload()
+              if (event.isUpdate) {
+                if (onNeedReload)
+                  onNeedReload()
+                else
+                  window.location.reload()
+              }
             })
 
             onNeedRefresh?.()

--- a/src/client/build/solid.ts
+++ b/src/client/build/solid.ts
@@ -7,6 +7,7 @@ export type { RegisterSWOptions }
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
     immediate = true,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -19,6 +20,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
 
   const updateServiceWorker = registerSW({
     immediate,
+    onNeedReload,
     onOfflineReady() {
       setOfflineReady(true)
       onOfflineReady?.()

--- a/src/client/build/svelte.ts
+++ b/src/client/build/svelte.ts
@@ -7,6 +7,7 @@ export type { RegisterSWOptions }
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
     immediate = true,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -19,6 +20,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
 
   const updateServiceWorker = registerSW({
     immediate,
+    onNeedReload,
     onOfflineReady() {
       offlineReady.set(true)
       onOfflineReady?.()

--- a/src/client/build/vue.ts
+++ b/src/client/build/vue.ts
@@ -7,6 +7,7 @@ export type { RegisterSWOptions }
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
     immediate = true,
+    onNeedReload,
     onNeedRefresh,
     onOfflineReady,
     onRegistered,
@@ -19,6 +20,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
 
   const updateServiceWorker = registerSW({
     immediate,
+    onNeedReload,
     onNeedRefresh() {
       needRefresh.value = true
       onNeedRefresh?.()

--- a/src/client/type.d.ts
+++ b/src/client/type.d.ts
@@ -1,5 +1,12 @@
 export interface RegisterSWOptions {
   immediate?: boolean
+  /**
+   * Called when the service worker has taken control and the page would normally reload.
+   *
+   * Useful to fully control the reload flow (for example, to defer reload until the next
+   * SPA navigation).
+   */
+  onNeedReload?: () => void
   onNeedRefresh?: () => void
   onOfflineReady?: () => void
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,12 @@
 export interface RegisterSWOptions {
   immediate?: boolean
+  /**
+   * Called when the service worker has taken control and the page would normally reload.
+   *
+   * Useful to fully control the reload flow (for example, to defer reload until the next
+   * SPA navigation).
+   */
+  onNeedReload?: () => void
   onNeedRefresh?: () => void
   onOfflineReady?: () => void
   /**


### PR DESCRIPTION
We have `@tanstack/router` and i have monkey-patched navigation to pass the reloadDocument boolean on the next navigation when we know there is a new version available. Currently we have a patch file that implements this in React.

## What
Adds a new `onNeedReload` callback to the `registerSW()` options. It is invoked whenever the plugin would normally hard-reload the page after a service worker update takes control.

## Why
Some SPAs need to fully control when a reload happens (e.g. defer it until the next router navigation, show a custom confirmation UI, or preserve in-progress form state). Today the built-in client always calls `window.location.reload()`.

## Details
- Runtime: `src/client/build/register.ts` calls `onNeedReload()` (fallback to `window.location.reload()`) in both:
  - `registerType: 'autoUpdate'` on `activated` (update/external)
  - `registerType: 'prompt'` on `controlling` after `updateSW()` triggers `skipWaiting`
- Framework wrappers: forward `onNeedReload` through `virtual:pwa-register/{react,vue,svelte,solid,preact}`.
- Types: updated `src/client/type.d.ts` and `types/index.d.ts`.
- Docs: updated guides and framework type declaration snippets to document `onNeedReload`.

## Notes
This preserves current behavior when `onNeedReload` is not provided.
