### PR TITLE
feat: add vite 8 peer dependency support

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^1.0.0",
-    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "workbox-build": "^7.4.0",
     "workbox-window": "^7.4.0"
   },


### PR DESCRIPTION
## Summary

Add `^8.0.0` to the `vite` peer dependency range so that projects using Vite 8 can install `vite-plugin-pwa` without overrides or `--legacy-peer-deps`.

closes #918
closes #923

## Context

Vite 8 has been out for a while and several users in #918 have reported that the plugin works correctly with it in production. In our project we've been using it with Vite 8 via an npm override (`"vite-plugin-pwa": { "vite": "$vite" }`) without issues, though our usage is limited to standard precaching with `generateSW`.

That said, I realize there may be a reason this hasn't been added yet. Perhaps you're waiting to ship it alongside #903 (Vite Environment API support), or want to do broader testing across all plugin modes first. If so, totally understand. Happy to close this if the timing isn't right, or adjust the PR to fit into a larger release if that's more helpful.

## Changes

- `package.json`: Add `|| ^8.0.0` to `peerDependencies.vite`