### PR TITLE
docs(astro): fix grammar in Astro WIP placeholder

### DIFF
--- a/docs/frameworks/astro.md
+++ b/docs/frameworks/astro.md
@@ -6,5 +6,5 @@ next: Getting Started | Examples
 # Astro
 
 ::: info WIP
-Will coming soon.
+Coming soon.
 :::


### PR DESCRIPTION
Trivial grammar fix: \`Will coming soon\` → \`Coming soon\`.

\`will\` takes a bare infinitive (\`will come\`), not a present participle (\`coming\`). The simplest correction is to drop the modal verb and keep just \`Coming soon\`, which matches similar placeholders elsewhere in the docs.