### PR TITLE
Fix: remove the `event.isUpdate` check in controlling handler

### DIFF
--- a/src/client/build/register.ts
+++ b/src/client/build/register.ts
@@ -87,13 +87,11 @@ export function registerSW(options: RegisterSWOptions = {}) {
             // Assuming the user accepted the update, set up a listener
             // that will reload the page as soon as the previously waiting
             // service worker has taken control.
-            wb?.addEventListener('controlling', (event) => {
-              if (event.isUpdate) {
-                if (onNeedReload)
-                  onNeedReload()
-                else
-                  window.location.reload()
-              }
+            wb?.addEventListener('controlling', (_event) => {
+              if (onNeedReload)
+                onNeedReload()
+              else
+                window.location.reload()
             })
 
             onNeedRefresh?.()


### PR DESCRIPTION
### Description

The check for `event.isUpdate` is preventing the `onNeedReload()` callback from being executed on first update.

This event property indicates that it's an update to service worker that was available when workbox-window was registered.

In case of first update there wasn't a service worker at the time when Workbox has started, so it's value is `false`.

Full explanation and reproduction is in linked issue

### Linked Issues

fixes #789