### PR TITLE
fix(react): avoid duplicate SW registration in strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,14 +100,15 @@
     "example:vue:build:cdn": "pnpm -C examples/vue-basic-cdn run build",
     "example:vue:start:cdn": "pnpm -C examples/vue-basic-cdn run start",
     "deploy": "nr build && nr docs:build",
+    "test-client": "vitest run test/*.test.ts",
     "test-vue": "pnpm -C examples/vue-router run test",
     "test-react": "pnpm -C examples/react-router run test",
     "test-preact": "pnpm -C examples/preact-router run test",
     "test-solid": "pnpm -C examples/solid-router run test",
     "test-svelte": "pnpm -C examples/svelte-routify run test",
     "test-typescript": "pnpm -C examples/vanilla-ts-no-ip run test",
-    "test": "nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-typescript",
-    "test:node20": "nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-svelte && nr test-typescript",
+    "test": "nr test-client && nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-typescript",
+    "test:node20": "nr test-client && nr test-vue && nr test-react && nr test-preact && nr test-solid && nr test-svelte && nr test-typescript",
     "test:vite-ecosystem-ci": "nr test-typescript"
   },
   "peerDependencies": {

--- a/src/client/build/react.ts
+++ b/src/client/build/react.ts
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { RegisterSWOptions } from '../type'
 import { registerSW } from './register'
 
 export type { RegisterSWOptions }
+
+type UpdateServiceWorker = ReturnType<typeof registerSW>
 
 export function useRegisterSW(options: RegisterSWOptions = {}) {
   const {
@@ -17,9 +19,21 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
 
   const [needRefresh, setNeedRefresh] = useState(false)
   const [offlineReady, setOfflineReady] = useState(false)
+  const registered = useRef(false)
+  const updateServiceWorkerRef = useRef<UpdateServiceWorker>()
 
-  const [updateServiceWorker] = useState(() => {
-    return registerSW({
+  const [updateServiceWorker] = useState<UpdateServiceWorker>(() => {
+    return async (...args) => {
+      await updateServiceWorkerRef.current?.(...args)
+    }
+  })
+
+  useEffect(() => {
+    if (registered.current)
+      return
+
+    registered.current = true
+    updateServiceWorkerRef.current = registerSW({
       immediate,
       onNeedReload,
       onOfflineReady() {
@@ -34,7 +48,7 @@ export function useRegisterSW(options: RegisterSWOptions = {}) {
       onRegisteredSW,
       onRegisterError,
     })
-  })
+  }, [])
 
   return {
     needRefresh: [needRefresh, setNeedRefresh],

--- a/test/react.test.ts
+++ b/test/react.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  type Effect = () => void | (() => void)
+
+  const state: unknown[] = []
+  const refs: Array<{ current: unknown }> = []
+  const effects: Effect[] = []
+  const updateServiceWorker = vi.fn(async () => {})
+  const registerSW = vi.fn(() => updateServiceWorker)
+  let stateIndex = 0
+  let refIndex = 0
+
+  function beginRender() {
+    stateIndex = 0
+    refIndex = 0
+    effects.length = 0
+  }
+
+  return {
+    registerSW,
+    updateServiceWorker,
+    reset() {
+      state.length = 0
+      refs.length = 0
+      beginRender()
+      registerSW.mockClear()
+      updateServiceWorker.mockClear()
+    },
+    render<T>(callback: () => T) {
+      beginRender()
+      return callback()
+    },
+    runStrictEffects() {
+      for (const effect of effects) {
+        const cleanup = effect()
+        if (typeof cleanup === 'function')
+          cleanup()
+        effect()
+      }
+    },
+    useEffect(effect: Effect) {
+      effects.push(effect)
+    },
+    useRef<T>(initialValue?: T) {
+      const index = refIndex++
+      if (!(index in refs))
+        refs[index] = { current: initialValue }
+
+      return refs[index] as { current: T | undefined }
+    },
+    useState<T>(initialState: T | (() => T)): [T, (value: T) => void] {
+      const index = stateIndex++
+      if (!(index in state)) {
+        if (typeof initialState === 'function') {
+          const initializer = initialState as () => T
+          initializer()
+          state[index] = initializer()
+        }
+        else {
+          state[index] = initialState
+        }
+      }
+
+      return [
+        state[index] as T,
+        (value: T) => {
+          state[index] = value
+        },
+      ]
+    },
+  }
+})
+
+vi.mock('react', () => ({
+  useEffect: mocks.useEffect,
+  useRef: mocks.useRef,
+  useState: mocks.useState,
+}))
+
+vi.mock('../src/client/build/register', () => ({
+  registerSW: mocks.registerSW,
+}))
+
+const { useRegisterSW } = await import('../src/client/build/react')
+
+describe('useRegisterSW for React', () => {
+  beforeEach(() => {
+    mocks.reset()
+  })
+
+  it('registers once after render when React StrictMode double-invokes hooks', async () => {
+    const onRegistered = vi.fn()
+    const result = mocks.render(() => useRegisterSW({ onRegistered }))
+
+    expect(mocks.registerSW).not.toHaveBeenCalled()
+
+    mocks.runStrictEffects()
+
+    expect(mocks.registerSW).toHaveBeenCalledTimes(1)
+    expect(mocks.registerSW).toHaveBeenCalledWith(expect.objectContaining({
+      immediate: true,
+      onRegistered,
+    }))
+
+    await result.updateServiceWorker(false)
+
+    expect(mocks.updateServiceWorker).toHaveBeenCalledTimes(1)
+    expect(mocks.updateServiceWorker).toHaveBeenCalledWith(false)
+  })
+})


### PR DESCRIPTION
### Description

Moves React `useRegisterSW` service worker registration out of the `useState` lazy initializer and into a guarded effect. The returned `updateServiceWorker` function stays stable and forwards to the registered updater via a ref, so React StrictMode development double-invocation does not register the service worker twice.

Added a focused Vitest coverage case that simulates StrictMode double-invoking state initializers/effects and verifies a single registration.

### Linked Issues

Fixes #925

### Additional Context

Verification:
- `pnpm run test-client`
- `pnpm run lint`
- `pnpm run build`
- `pnpm -C examples/react-router run run-build-claims && pnpm -C examples/react-router exec vitest run`
- `pnpm -C examples/react-router run run-build-sw-claims && SW=true pnpm -C examples/react-router exec vitest run`
- `git diff --check`
