### PR TITLE
fix: emit manifest.webmanifest relative to custom outDir

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         version: 4.2.5
       tsup:
         specifier: ^7.3.0
-        version: 7.3.0(postcss@8.4.49)(typescript@5.3.3)
+        version: 7.3.0(postcss@8.5.14)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -107,17 +107,17 @@ importers:
     dependencies:
       '@vueuse/core':
         specifier: ^9.2.0
-        version: 9.2.0(vue@3.5.12(typescript@4.8.2))
+        version: 9.2.0(vue@3.5.34(typescript@4.8.2))
       '@vueuse/shared':
         specifier: ^9.2.0
-        version: 9.2.0(vue@3.5.12(typescript@4.8.2))
+        version: 9.2.0(vue@3.5.34(typescript@4.8.2))
     devDependencies:
       '@types/fs-extra':
         specifier: ^9.0.13
         version: 9.0.13
       '@vitejs/plugin-vue':
         specifier: ^3.1.0
-        version: 3.1.0(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.12(typescript@4.8.2))
+        version: 3.1.0(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.34(typescript@4.8.2))
       esbuild-register:
         specifier: ^3.3.3
         version: 3.3.3(esbuild@0.21.5)
@@ -138,16 +138,16 @@ importers:
         version: 4.8.2
       unocss:
         specifier: ^0.45.18
-        version: 0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+        version: 0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       unplugin-vue-components:
         specifier: ^0.22.4
-        version: 0.22.4(@babel/parser@7.26.2)(esbuild@0.21.5)(rollup@4.47.1)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.12(typescript@4.8.2))
+        version: 0.22.4(@babel/parser@7.29.3)(esbuild@0.21.5)(rollup@4.60.4)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.34(typescript@4.8.2))
       vite-plugin-pwa:
         specifier: workspace:*
         version: link:..
       vitepress:
         specifier: 1.0.1
-        version: 1.0.1(@algolia/client-search@5.13.0)(@types/node@18.17.14)(@types/react@18.2.37)(postcss@8.4.49)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.2)(terser@5.31.0)(typescript@4.8.2)
+        version: 1.0.1(@algolia/client-search@5.13.0)(@types/node@18.17.14)(@types/react@18.2.37)(postcss@8.5.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.2)(terser@5.31.0)(typescript@4.8.2)
       workbox-window:
         specifier: ^7.4.0
         version: 7.4.0
@@ -187,7 +187,7 @@ importers:
         version: 2.7.0(@babel/core@7.24.5)(preact@10.19.7)(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -236,7 +236,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.37
@@ -291,7 +291,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       https-localhost:
         specifier: ^4.7.1
         version: 4.7.1
@@ -327,7 +327,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       '@roxi/routify':
         specifier: ^2.18.12
         version: 2.18.12
@@ -354,10 +354,10 @@ importers:
         version: 4.2.5
       svelte-check:
         specifier: ^3.6.0
-        version: 3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.5)
+        version: 3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@4.2.5)
       svelte-preprocess:
         specifier: ^5.1.0
-        version: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.5)(typescript@5.3.3)
+        version: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@4.2.5)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -384,10 +384,10 @@ importers:
         version: 4.0.0(rollup@4.47.1)
       '@sveltejs/adapter-static':
         specifier: next
-        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)))
+        version: 1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)))
       '@sveltejs/kit':
         specifier: next
-        version: 1.0.0-next.589(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+        version: 1.0.0-next.589(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.30.3
         version: 5.36.2(@typescript-eslint/parser@5.36.2(eslint@8.54.0)(typescript@4.8.2))(eslint@8.54.0)(typescript@4.8.2)
@@ -417,10 +417,10 @@ importers:
         version: 3.50.0
       svelte-check:
         specifier: ^2.8.0
-        version: 2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0)
+        version: 2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0)
       svelte-preprocess:
         specifier: ^4.10.7
-        version: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0)(typescript@4.8.2)
+        version: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0)(typescript@4.8.2)
       tslib:
         specifier: ^2.4.0
         version: 2.4.0
@@ -526,7 +526,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       '@vitejs/plugin-vue':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -557,7 +557,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.47.1)
+        version: 5.0.5(rollup@4.60.4)
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
         version: 4.5.0(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))
@@ -920,12 +920,20 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.22.15':
@@ -974,6 +982,11 @@ packages:
 
   '@babel/parser@7.26.2':
     resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1468,6 +1481,10 @@ packages:
 
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@canvas/image-data@1.0.0':
@@ -2204,6 +2221,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.15':
     resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
 
@@ -2355,8 +2375,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.47.1':
     resolution: {integrity: sha512-uqxkb3RJLzlBbh/bbNQ4r7YpSZnjgMgyoEOY7Fy6GCbelkDSAzeiogxMG9TfLsBbqmGsdDObo3mzGqa8hps4MA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
     cpu: [arm64]
     os: [android]
 
@@ -2365,8 +2395,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.47.1':
     resolution: {integrity: sha512-XuJRPTnMk1lwsSnS3vYyVMu4x/+WIw1MMSiqj5C4j3QOWsMzbJEK90zG+SWV1h0B1ABGCQ0UZUjti+TQK35uHQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2375,8 +2415,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.47.1':
     resolution: {integrity: sha512-OQ2/ZDGzdOOlyfqBiip0ZX/jVFekzYrGtUsqAfLDbWy0jh1PUU18+jYp8UMpqhly5ltEqotc2miLngf9FPSWIA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
     cpu: [x64]
     os: [freebsd]
 
@@ -2385,8 +2435,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.47.1':
     resolution: {integrity: sha512-sZ5p2I9UA7T950JmuZ3pgdKA6+RTBr+0FpK427ExW0t7n+QwYOcmDTK/aRlzoBrWyTpJNlS3kacgSlSTUg6P/Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
 
@@ -2395,9 +2455,29 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.47.1':
     resolution: {integrity: sha512-49J4FnMHfGodJWPw73Ve+/hsPjZgcXQGkmqBGZFvltzBKRS+cvMiWNLadOMXKGnYRhs1ToTGM0sItKISoSGUNA==}
     cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.47.1':
@@ -2410,8 +2490,23 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.47.1':
     resolution: {integrity: sha512-daoT0PMENNdjVYYU9xec30Y2prb1AbEIbb64sqkcQcSaR0zYuKkoPuhIztfxuqN82KYCKKrj+tQe4Gi7OSm1ow==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
 
@@ -2420,8 +2515,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.47.1':
     resolution: {integrity: sha512-U/CHbqKSwEQyZXjCpY43/GLYcTVKEXeRHw0rMBJP7fP3x6WpYG4LTJWR3ic6TeYKX6ZK7mrhltP4ppolyVhLVQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
 
@@ -2430,13 +2535,38 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.47.1':
     resolution: {integrity: sha512-Ft+d/9DXs30BK7CHCTX11FtQGHUdpNDLJW0HHLign4lgMgBcPFN3NkdIXhC5r9iwsMwYreBBc4Rho5ieOmKNVQ==}
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.47.1':
     resolution: {integrity: sha512-N9X5WqGYzZnjGAFsKSfYFtAShYjwOmFJoWbLg3dYixZOZqU7hdMq+/xyS14zKLhFhZDhP9VfkzQnsdk0ZDS9IA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
     cpu: [arm64]
     os: [win32]
 
@@ -2445,8 +2575,23 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.47.1':
     resolution: {integrity: sha512-CpKnYa8eHthJa3c+C38v/E+/KZyF1Jdh2Cz3DyKZqEWYgrM1IHFArXNWvBLPQCKUEsAqqKX27tTqVEFbDNUcOA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
 
@@ -2978,11 +3123,17 @@ packages:
   '@vue/compiler-core@3.5.12':
     resolution: {integrity: sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==}
 
+  '@vue/compiler-core@3.5.34':
+    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
+
   '@vue/compiler-dom@3.3.8':
     resolution: {integrity: sha512-+PPtv+p/nWDd0AvJu3w8HS0RIm/C6VGBIRe24b9hSyNWOAPEUosFZ5diwawwP8ip5sJ8n0Pe87TNNNHnvjs0FQ==}
 
   '@vue/compiler-dom@3.5.12':
     resolution: {integrity: sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==}
+
+  '@vue/compiler-dom@3.5.34':
+    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
 
   '@vue/compiler-sfc@3.3.8':
     resolution: {integrity: sha512-WMzbUrlTjfYF8joyT84HfwwXo+8WPALuPxhy+BZ6R4Aafls+jDBnSz8PDz60uFhuqFbl3HxRfxvDzrUf3THwpA==}
@@ -2990,11 +3141,17 @@ packages:
   '@vue/compiler-sfc@3.5.12':
     resolution: {integrity: sha512-2k973OGo2JuAa5+ZlekuQJtitI5CgLMOwgl94BzMCsKZCX/xiqzJYzapl4opFogKHqwJk34vfsaKpfEhd1k5nw==}
 
+  '@vue/compiler-sfc@3.5.34':
+    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
+
   '@vue/compiler-ssr@3.3.8':
     resolution: {integrity: sha512-hXCqQL/15kMVDBuoBYpUnSYT8doDNwsjvm3jTefnXr+ytn294ySnT8NlsFHmTgKNjwpuFy7XVV8yTeLtNl/P6w==}
 
   '@vue/compiler-ssr@3.5.12':
     resolution: {integrity: sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==}
+
+  '@vue/compiler-ssr@3.5.34':
+    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
 
   '@vue/devtools-api@6.5.0':
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
@@ -3017,17 +3174,26 @@ packages:
   '@vue/reactivity@3.5.12':
     resolution: {integrity: sha512-UzaN3Da7xnJXdz4Okb/BGbAaomRHc3RdoWqTzlvd9+WBR5m3J39J1fGcHes7U3za0ruYn/iYy/a1euhMEHvTAg==}
 
+  '@vue/reactivity@3.5.34':
+    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
+
   '@vue/runtime-core@3.3.8':
     resolution: {integrity: sha512-qurzOlb6q26KWQ/8IShHkMDOuJkQnQcTIp1sdP4I9MbCf9FJeGVRXJFr2mF+6bXh/3Zjr9TDgURXrsCr9bfjUw==}
 
   '@vue/runtime-core@3.5.12':
     resolution: {integrity: sha512-hrMUYV6tpocr3TL3Ad8DqxOdpDe4zuQY4HPY3X/VRh+L2myQO8MFXPAMarIOSGNu0bFAjh1yBkMPXZBqCk62Uw==}
 
+  '@vue/runtime-core@3.5.34':
+    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
+
   '@vue/runtime-dom@3.3.8':
     resolution: {integrity: sha512-Noy5yM5UIf9UeFoowBVgghyGGPIDPy1Qlqt0yVsUdAVbqI8eeMSsTqBtauaEoT2UFXUk5S64aWVNJN4MJ2vRdA==}
 
   '@vue/runtime-dom@3.5.12':
     resolution: {integrity: sha512-q8VFxR9A2MRfBr6/55Q3umyoN7ya836FzRXajPB6/Vvuv0zOPL+qltd9rIMzG/DbRLAIlREmnLsplEF/kotXKA==}
+
+  '@vue/runtime-dom@3.5.34':
+    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
 
   '@vue/server-renderer@3.3.8':
     resolution: {integrity: sha512-zVCUw7RFskvPuNlPn/8xISbrf0zTWsTSdYTsUTN1ERGGZGVnRxM2QZ3x1OR32+vwkkCm0IW6HmJ49IsPm7ilLg==}
@@ -3039,11 +3205,19 @@ packages:
     peerDependencies:
       vue: 3.5.12
 
+  '@vue/server-renderer@3.5.34':
+    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
+    peerDependencies:
+      vue: 3.5.34
+
   '@vue/shared@3.3.8':
     resolution: {integrity: sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw==}
 
   '@vue/shared@3.5.12':
     resolution: {integrity: sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==}
+
+  '@vue/shared@3.5.34':
+    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -3598,6 +3772,9 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
@@ -3780,6 +3957,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.21.2:
@@ -4299,25 +4480,27 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4849,6 +5032,9 @@ packages:
   magic-string@0.30.12:
     resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
     engines: {node: '>=12'}
@@ -5126,6 +5312,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
@@ -5420,6 +5611,10 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   preact-router@4.1.2:
     resolution: {integrity: sha512-uICUaUFYh+XQ+6vZtQn1q+X6rSqwq+zorWOCLWPF5FAsQh3EJ+RsDQ9Ee+fjk545YWQHfUxhrBAaemfxEnMOUg==}
     peerDependencies:
@@ -5659,6 +5854,11 @@ packages:
 
   rollup@4.47.1:
     resolution: {integrity: sha512-iasGAQoZ5dWDzULEUX3jiW0oB1qyFOepSyDyoU6S/OhVlDIwj5knI5QBa5RRQ0sK7OE0v+8VIi2JuV+G+3tfNg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6096,6 +6296,7 @@ packages:
   tar@6.1.15:
     resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -6541,6 +6742,37 @@ packages:
       terser:
         optional: true
 
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vitefu@0.2.4:
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -6654,6 +6886,14 @@ packages:
       typescript:
         optional: true
 
+  vue@3.5.34:
+    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
     deprecated: Use your platform's native performance.now() and performance.timeOrigin.
@@ -6688,6 +6928,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
@@ -7315,9 +7556,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.22.15': {}
 
@@ -7373,6 +7618,10 @@ snapshots:
   '@babel/parser@7.26.2':
     dependencies:
       '@babel/types': 7.26.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.24.5)':
     dependencies:
@@ -7994,6 +8243,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
   '@canvas/image-data@1.0.0': {}
 
   '@clack/core@0.4.1':
@@ -8541,6 +8795,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.15':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
@@ -8669,12 +8925,12 @@ snapshots:
       magic-string: 0.25.9
       rollup: 4.47.1
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.47.1)':
+  '@rollup/plugin-replace@5.0.5(rollup@4.60.4)':
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@4.47.1)
+      '@rollup/pluginutils': 5.0.2(rollup@4.60.4)
       magic-string: 0.30.3
     optionalDependencies:
-      rollup: 4.47.1
+      rollup: 4.60.4
 
   '@rollup/plugin-terser@0.4.4(rollup@4.47.1)':
     dependencies:
@@ -8704,34 +8960,78 @@ snapshots:
     optionalDependencies:
       rollup: 4.47.1
 
+  '@rollup/pluginutils@5.0.2(rollup@4.60.4)':
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.60.4
+
   '@rollup/rollup-android-arm-eabi@4.47.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
   '@rollup/rollup-android-arm64@4.47.1':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.47.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.47.1':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.47.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.47.1':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.47.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.47.1':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.47.1':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.47.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.47.1':
@@ -8740,28 +9040,67 @@ snapshots:
   '@rollup/rollup-linux-ppc64-gnu@4.47.1':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.47.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.47.1':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.47.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.47.1':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.47.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.47.1':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.47.1':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.47.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
   '@roxi/routify@2.18.12':
@@ -8849,13 +9188,13 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.7
 
-  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)))':
+  '@sveltejs/adapter-static@1.0.0-next.50(@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)))':
     dependencies:
-      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@sveltejs/kit': 1.0.0-next.589(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
 
-  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))':
+  '@sveltejs/kit@1.0.0-next.589(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.2.0
@@ -8869,16 +9208,16 @@ snapshots:
       svelte: 3.50.0
       tiny-glob: 0.2.9
       undici: 5.14.0
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.4.0
       svelte: 3.50.0
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8891,17 +9230,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))':
+  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)))(svelte@3.50.0)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       debug: 4.3.6
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.3
       svelte: 3.50.0
       svelte-hmr: 0.15.3(svelte@3.50.0)
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
-      vitefu: 0.2.4(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
+      vitefu: 0.2.4(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9235,11 +9574,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/astro@0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))':
+  '@unocss/astro@0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@unocss/core': 0.45.18
       '@unocss/reset': 0.45.18
-      '@unocss/vite': 0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@unocss/vite': 0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - vite
 
@@ -9329,7 +9668,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.45.18
 
-  '@unocss/vite@0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))':
+  '@unocss/vite@0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))':
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@rollup/pluginutils': 4.2.1
@@ -9339,7 +9678,7 @@ snapshots:
       '@unocss/scope': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       magic-string: 0.26.7
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
 
   '@unrs/rspack-resolver-binding-darwin-arm64@1.2.2':
     optional: true
@@ -9396,10 +9735,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@3.1.0(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.12(typescript@4.8.2))':
+  '@vitejs/plugin-vue@3.1.0(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.34(typescript@4.8.2))':
     dependencies:
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
-      vue: 3.5.12(typescript@4.8.2)
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
+      vue: 3.5.34(typescript@4.8.2)
 
   '@vitejs/plugin-vue@4.3.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0))(vue@3.3.8(typescript@5.3.3))':
     dependencies:
@@ -9467,6 +9806,14 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/shared': 3.5.34
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.3.8':
     dependencies:
       '@vue/compiler-core': 3.3.8
@@ -9476,6 +9823,11 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.5.12
       '@vue/shared': 3.5.12
+
+  '@vue/compiler-dom@3.5.34':
+    dependencies:
+      '@vue/compiler-core': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/compiler-sfc@3.3.8':
     dependencies:
@@ -9502,6 +9854,18 @@ snapshots:
       postcss: 8.4.49
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.34
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.14
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.3.8':
     dependencies:
       '@vue/compiler-dom': 3.3.8
@@ -9511,6 +9875,11 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.12
       '@vue/shared': 3.5.12
+
+  '@vue/compiler-ssr@3.5.34':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/devtools-api@6.5.0': {}
 
@@ -9548,6 +9917,10 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.12
 
+  '@vue/reactivity@3.5.34':
+    dependencies:
+      '@vue/shared': 3.5.34
+
   '@vue/runtime-core@3.3.8':
     dependencies:
       '@vue/reactivity': 3.3.8
@@ -9557,6 +9930,11 @@ snapshots:
     dependencies:
       '@vue/reactivity': 3.5.12
       '@vue/shared': 3.5.12
+
+  '@vue/runtime-core@3.5.34':
+    dependencies:
+      '@vue/reactivity': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/runtime-dom@3.3.8':
     dependencies:
@@ -9571,6 +9949,13 @@ snapshots:
       '@vue/shared': 3.5.12
       csstype: 3.1.3
 
+  '@vue/runtime-dom@3.5.34':
+    dependencies:
+      '@vue/reactivity': 3.5.34
+      '@vue/runtime-core': 3.5.34
+      '@vue/shared': 3.5.34
+      csstype: 3.2.3
+
   '@vue/server-renderer@3.3.8(vue@3.3.8(typescript@5.3.3))':
     dependencies:
       '@vue/compiler-ssr': 3.3.8
@@ -9583,9 +9968,17 @@ snapshots:
       '@vue/shared': 3.5.12
       vue: 3.5.12(typescript@4.8.2)
 
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@4.8.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@4.8.2)
+
   '@vue/shared@3.3.8': {}
 
   '@vue/shared@3.5.12': {}
+
+  '@vue/shared@3.5.34': {}
 
   '@vueuse/core@10.11.1(vue@3.5.12(typescript@4.8.2))':
     dependencies:
@@ -9607,12 +10000,12 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@9.2.0(vue@3.5.12(typescript@4.8.2))':
+  '@vueuse/core@9.2.0(vue@3.5.34(typescript@4.8.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.15
       '@vueuse/metadata': 9.2.0
-      '@vueuse/shared': 9.2.0(vue@3.5.12(typescript@4.8.2))
-      vue-demi: 0.13.11(vue@3.5.12(typescript@4.8.2))
+      '@vueuse/shared': 9.2.0(vue@3.5.34(typescript@4.8.2))
+      vue-demi: 0.13.11(vue@3.5.34(typescript@4.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9648,9 +10041,9 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@9.2.0(vue@3.5.12(typescript@4.8.2))':
+  '@vueuse/shared@9.2.0(vue@3.5.34(typescript@4.8.2))':
     dependencies:
-      vue-demi: 0.13.11(vue@3.5.12(typescript@4.8.2))
+      vue-demi: 0.13.11(vue@3.5.34(typescript@4.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -10154,6 +10547,8 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  csstype@3.2.3: {}
+
   data-urls@2.0.0:
     dependencies:
       abab: 2.0.6
@@ -10282,6 +10677,8 @@ snapshots:
       tapable: 2.2.1
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-abstract@1.21.2:
     dependencies:
@@ -11613,6 +12010,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magic-string@0.30.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -12048,6 +12449,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.12: {}
+
   nanoid@3.3.6: {}
 
   nanoid@3.3.7: {}
@@ -12284,12 +12687,12 @@ snapshots:
     dependencies:
       yaml: 2.7.0
 
-  postcss-load-config@4.0.1(postcss@8.4.49):
+  postcss-load-config@4.0.1(postcss@8.5.14):
     dependencies:
       lilconfig: 2.0.6
       yaml: 2.1.1
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -12311,6 +12714,12 @@ snapshots:
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12571,6 +12980,37 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.47.1
       '@rollup/rollup-win32-ia32-msvc': 4.47.1
       '@rollup/rollup-win32-x64-msvc': 4.47.1
+      fsevents: 2.3.3
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
   rspack-resolver@1.2.2:
@@ -12966,7 +13406,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0):
+  svelte-check@2.9.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.15
       chokidar: 3.5.3
@@ -12975,7 +13415,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.50.0
-      svelte-preprocess: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0)(typescript@4.9.4)
+      svelte-preprocess: 4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0)(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -12989,7 +13429,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.5):
+  svelte-check@3.6.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@4.2.5):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       chokidar: 3.5.3
@@ -12998,7 +13438,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.5
-      svelte-preprocess: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.5)(typescript@5.3.3)
+      svelte-preprocess: 5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@4.2.5)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -13019,7 +13459,7 @@ snapshots:
     dependencies:
       svelte: 4.2.5
 
-  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0)(typescript@4.8.2):
+  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0)(typescript@4.8.2):
     dependencies:
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
@@ -13030,11 +13470,11 @@ snapshots:
       svelte: 3.50.0
     optionalDependencies:
       '@babel/core': 7.24.5
-      postcss: 8.4.49
-      postcss-load-config: 4.0.1(postcss@8.4.49)
+      postcss: 8.5.14
+      postcss-load-config: 4.0.1(postcss@8.5.14)
       typescript: 4.8.2
 
-  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@3.50.0)(typescript@4.9.4):
+  svelte-preprocess@4.10.7(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@3.50.0)(typescript@4.9.4):
     dependencies:
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
@@ -13045,11 +13485,11 @@ snapshots:
       svelte: 3.50.0
     optionalDependencies:
       '@babel/core': 7.24.5
-      postcss: 8.4.49
-      postcss-load-config: 4.0.1(postcss@8.4.49)
+      postcss: 8.5.14
+      postcss-load-config: 4.0.1(postcss@8.5.14)
       typescript: 4.9.4
 
-  svelte-preprocess@5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.5)(typescript@5.3.3):
+  svelte-preprocess@5.1.0(@babel/core@7.24.5)(postcss-load-config@4.0.1(postcss@8.5.14))(postcss@8.5.14)(svelte@4.2.5)(typescript@5.3.3):
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
@@ -13059,8 +13499,8 @@ snapshots:
       svelte: 4.2.5
     optionalDependencies:
       '@babel/core': 7.24.5
-      postcss: 8.4.49
-      postcss-load-config: 4.0.1(postcss@8.4.49)
+      postcss: 8.5.14
+      postcss-load-config: 4.0.1(postcss@8.5.14)
       typescript: 5.3.3
 
   svelte@3.50.0: {}
@@ -13203,7 +13643,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@7.3.0(postcss@8.4.49)(typescript@5.3.3):
+  tsup@7.3.0(postcss@8.5.14)(typescript@5.3.3):
     dependencies:
       bundle-require: 4.0.1(esbuild@0.19.5)
       cac: 6.7.14
@@ -13213,14 +13653,14 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.49)
+      postcss-load-config: 4.0.1(postcss@8.5.14)
       resolve-from: 5.0.0
       rollup: 4.47.1
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13349,9 +13789,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)):
+  unocss@0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)):
     dependencies:
-      '@unocss/astro': 0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@unocss/astro': 0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
       '@unocss/cli': 0.45.18
       '@unocss/core': 0.45.18
       '@unocss/preset-attributify': 0.45.18
@@ -13367,14 +13807,14 @@ snapshots:
       '@unocss/transformer-compile-class': 0.45.18
       '@unocss/transformer-directives': 0.45.18
       '@unocss/transformer-variant-group': 0.45.18
-      '@unocss/vite': 0.45.18(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
+      '@unocss/vite': 0.45.18(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
     transitivePeerDependencies:
       - supports-color
       - vite
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.22.4(@babel/parser@7.26.2)(esbuild@0.21.5)(rollup@4.47.1)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.12(typescript@4.8.2)):
+  unplugin-vue-components@0.22.4(@babel/parser@7.29.3)(esbuild@0.21.5)(rollup@4.60.4)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))(vue@3.5.34(typescript@4.8.2)):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -13385,10 +13825,10 @@ snapshots:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5(esbuild@0.21.5)(rollup@4.47.1)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0))
-      vue: 3.5.12(typescript@4.8.2)
+      unplugin: 0.9.5(esbuild@0.21.5)(rollup@4.60.4)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0))
+      vue: 3.5.34(typescript@4.8.2)
     optionalDependencies:
-      '@babel/parser': 7.26.2
+      '@babel/parser': 7.29.3
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -13396,7 +13836,7 @@ snapshots:
       - vite
       - webpack
 
-  unplugin@0.9.5(esbuild@0.21.5)(rollup@4.47.1)(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)):
+  unplugin@0.9.5(esbuild@0.21.5)(rollup@4.60.4)(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)):
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
@@ -13404,8 +13844,8 @@ snapshots:
       webpack-virtual-modules: 0.4.4
     optionalDependencies:
       esbuild: 0.21.5
-      rollup: 4.47.1
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
+      rollup: 4.60.4
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
 
   upath@1.2.0: {}
 
@@ -13519,19 +13959,29 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.31.0
 
+  vite@5.4.21(@types/node@18.17.14)(terser@5.31.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 18.17.14
+      fsevents: 2.3.3
+      terser: 5.31.0
+
   vitefu@0.2.4(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
       vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
 
-  vitefu@0.2.4(vite@5.4.11(@types/node@18.17.14)(terser@5.31.0)):
+  vitefu@0.2.4(vite@5.4.21(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
-      vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
+      vite: 5.4.21(@types/node@18.17.14)(terser@5.31.0)
 
   vitefu@0.2.5(vite@5.0.10(@types/node@18.17.14)(terser@5.31.0)):
     optionalDependencies:
       vite: 5.0.10(@types/node@18.17.14)(terser@5.31.0)
 
-  vitepress@1.0.1(@algolia/client-search@5.13.0)(@types/node@18.17.14)(@types/react@18.2.37)(postcss@8.4.49)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.2)(terser@5.31.0)(typescript@4.8.2):
+  vitepress@1.0.1(@algolia/client-search@5.13.0)(@types/node@18.17.14)(@types/react@18.2.37)(postcss@8.5.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.2)(terser@5.31.0)(typescript@4.8.2):
     dependencies:
       '@docsearch/css': 3.7.0
       '@docsearch/js': 3.7.0(@algolia/client-search@5.13.0)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.2)
@@ -13549,7 +13999,7 @@ snapshots:
       vite: 5.4.11(@types/node@18.17.14)(terser@5.31.0)
       vue: 3.5.12(typescript@4.8.2)
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -13613,9 +14063,9 @@ snapshots:
       - supports-color
       - terser
 
-  vue-demi@0.13.11(vue@3.5.12(typescript@4.8.2)):
+  vue-demi@0.13.11(vue@3.5.34(typescript@4.8.2)):
     dependencies:
-      vue: 3.5.12(typescript@4.8.2)
+      vue: 3.5.34(typescript@4.8.2)
 
   vue-demi@0.14.10(vue@3.5.12(typescript@4.8.2)):
     dependencies:
@@ -13660,6 +14110,16 @@ snapshots:
       '@vue/runtime-dom': 3.5.12
       '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@4.8.2))
       '@vue/shared': 3.5.12
+    optionalDependencies:
+      typescript: 4.8.2
+
+  vue@3.5.34(typescript@4.8.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@4.8.2))
+      '@vue/shared': 3.5.34
     optionalDependencies:
       typescript: 4.8.2
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@ import type { OutputAsset, OutputBundle, PluginContext } from 'rollup'
 import type { PWAPluginContext } from './context'
 import type { ExtendManifestEntriesHook, VitePluginPWAAPI } from './types'
 import { existsSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { cyan, yellow } from 'kolorist'
 import { generateWebManifestFile } from './assets'
 import { DEV_SW_NAME, FILE_SW_REGISTER } from './constants'
@@ -37,8 +37,15 @@ export function _generateBundle(ctx: PWAPluginContext, bundle?: OutputBundle, pl
         `${yellow('WARNING: "theme_color" is missing from the web manifest, your application will not be able to be installed')}`,
       ].join('\n'))
     }
+    // calculate relative path from main Vite outDir to PWA custom outDir
+    const mainOutDir = resolve(viteConfig.root, viteConfig.build.outDir || 'dist')
+    const pwaOutDir = resolve(viteConfig.root, options.outDir)
+    const subDir = relative(mainOutDir, pwaOutDir)
+    const manifestFileName = subDir
+      ? join(subDir, options.manifestFilename)
+      : options.manifestFilename
     emitFile({
-      fileName: options.manifestFilename,
+      fileName: manifestFileName,
       source: generateWebManifestFile(options),
     }, bundle, pluginCtx)
   }


### PR DESCRIPTION
## Summary
Fixes #919.

## Problem
When configuring a custom `outDir` (e.g., `outDir: 'dist/client/_pwa'`), the service worker (`sw.js`) and icons were correctly placed inside the `_pwa` directory. However, `manifest.webmanifest` was always generated in the root of the build output (e.g., `dist/client/manifest.webmanifest`), ignoring the `outDir` option.

## Solution
Calculate the relative path from the main Vite build output directory to the PWA custom output directory, and use this relative path when emitting the manifest file via `emitFile`.

## Changes
- **src/api.ts**: 
  - Added `join` and `relative` to imports.
  - Updated `_generateBundle` to compute `manifestFileName` based on the relative subdirectory between the Vite `build.outDir` and the PWA `outDir`.

## Verification
Using the configuration:
```typescript
VitePWA({

  outDir: 'dist/client/_pwa',

  buildBase: '/_pwa/'

})
## Before:
* `dist/client/manifest.webmanifest` (Incorrect location)
*  `dist/client/_pwa/sw.js` 
## After: 
* `dist/client/_pwa/manifest.webmanifest` (Correct location)
*  `dist/client/_pwa/sw.js` 


