### PR TITLE
chore: add pnpm override for baseline-browser-mapping to silence warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
   },
   "pnpm": {
     "overrides": {
+      "baseline-browser-mapping": "^2.1.0",
       "rollup": "^4.35.0"
     },
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Addresses #928.

The "data in this module is over two months old" warning is caused by a
stale transitive dependency bundled within workbox-build. 

Since we cannot update workbox-build directly without major refactoring,
this PR adds a pnpm override to force the latest version of 
baseline-browser-mapping globally, ensuring consumers have a clean build log.