### PR TITLE
feat: allow defining color_scheme_dark in manifest

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -473,7 +473,7 @@ export interface IconResource {
   purpose?: StringLiteralUnion<IconPurpose> | IconPurpose[]
 }
 
-export interface ManifestColorScheme {
+export interface ColorSchemeDark {
   background_color?: string
   theme_color?: string
 }
@@ -545,7 +545,7 @@ export interface ManifestOptions {
   /**
    * Colors used in dark mode.
    */
-  color_scheme_dark?: ManifestColorScheme
+  color_scheme_dark?: ColorSchemeDark
   /**
    * @default `ltr`
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,6 +473,11 @@ export interface IconResource {
   purpose?: StringLiteralUnion<IconPurpose> | IconPurpose[]
 }
 
+export interface ManifestColorScheme {
+  background_color?: string
+  theme_color?: string
+}
+
 export interface ManifestOptions {
   /**
    * @default _npm_package_name_
@@ -537,6 +542,10 @@ export interface ManifestOptions {
    * @default `#42b883`
    */
   theme_color: string
+  /**
+   * Colors used in dark mode.
+   */
+  color_scheme_dark?: ManifestColorScheme
   /**
    * @default `ltr`
    */


### PR DESCRIPTION
### Description

Allows defining `color_scheme_dark` in manifest, as allowed by the standard: https://w3c.github.io/manifest/#color_scheme_dark-member.

### Linked Issues

No related issues.