### PR TITLE
feat: support dark scheme colors in injectThemeColor

### DIFF
--- a/pwa-assets.d.ts
+++ b/pwa-assets.d.ts
@@ -13,11 +13,12 @@ declare module 'virtual:pwa-assets/head' {
   export interface ColorSchemeMeta {
     name: string
     content: string
+    media?: string
   }
 
   export interface PWAAssetsHead {
     links: PWAAssetHeadLink[]
-    themeColor?: ColorSchemeMeta
+    themeColors: ColorSchemeMeta[]
   }
 
   export const pwaAssetsHead: PWAAssetsHead

--- a/src/html.ts
+++ b/src/html.ts
@@ -116,17 +116,15 @@ import.meta.hot.on('${DEV_REGISTER_SW_NAME}', ({ mode, inlinePath, registerPath,
     document.head.appendChild(registerSW);
   }
 });
-import.meta.hot.on('${DEV_PWA_ASSETS_NAME}', ({ themeColor, links }) => {
-  if (themeColor) {
-    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-    if (metaThemeColor) {
-      metaThemeColor.content = themeColor.content;
-    } else {
+import.meta.hot.on('${DEV_PWA_ASSETS_NAME}', ({ themeColors, links }) => {
+  if (themeColors.length) {
+    themeColors.forEach((themeColor) => {
       const meta = document.createElement('meta');
       meta.setAttribute('name', 'theme-color');
       meta.setAttribute('content', themeColor.content);
+      if (themeColor.media) meta.setAttribute('media', themeColor.media);
       document.head.appendChild(meta);
-    }
+    });
   }
   if (links) {
     links.map((l) => {

--- a/src/plugins/pwa-assets.ts
+++ b/src/plugins/pwa-assets.ts
@@ -45,7 +45,7 @@ export function AssetsPlugin(ctx: PWAPluginContext) {
         // conditions are kept for backward compatibility for below Vite v6.3
         if (id === RESOLVED_PWA_ASSETS_HEAD_VIRTUAL) {
           const pwaAssetsGenerator = await ctx.pwaAssetsGenerator
-          const head = pwaAssetsGenerator?.resolveHtmlAssets() ?? { links: [], themeColor: undefined }
+          const head = pwaAssetsGenerator?.resolveHtmlAssets() ?? { links: [], themeColors: [] }
           return `export const pwaAssetsHead = ${JSON.stringify(head)}`
         }
         if (id === RESOLVED_PWA_ASSETS_ICONS_VIRTUAL) {

--- a/src/pwa-assets/html.ts
+++ b/src/pwa-assets/html.ts
@@ -1,5 +1,5 @@
 import type { PWAPluginContext } from '../context'
-import type { AssetsGeneratorContext, PWAHtmlAssets } from './types'
+import type { AssetsGeneratorContext, ColorSchemeMeta, PWAHtmlAssets } from './types'
 import { generateHtmlMarkup } from '@vite-pwa/assets-generator/api/generate-html-markup'
 import { checkForHtmlHead } from '../html'
 import { mapLink } from './utils'
@@ -10,11 +10,11 @@ export function transformIndexHtml(
   assetsGeneratorContext: AssetsGeneratorContext,
 ) {
   if (assetsGeneratorContext.injectThemeColor) {
-    const manifest = ctx.options.manifest
-    if (manifest && 'theme_color' in manifest && manifest.theme_color) {
+    const themeColors = resolveThemeColors(ctx)
+    if (themeColors.length) {
       html = checkForHtmlHead(html).replace(
         '</head>',
-        `\n<meta name="theme-color" content="${manifest.theme_color}"></head>`,
+        `\n${themeColors.map(colorSchemeMetaToHtml).join('\n')}</head>`,
       )
     }
   }
@@ -34,13 +34,10 @@ export function resolveHtmlAssets(
 ) {
   const header: PWAHtmlAssets = {
     links: [],
-    themeColor: undefined,
+    themeColors: [],
   }
-  if (assetsGeneratorContext.injectThemeColor) {
-    const manifest = ctx.options.manifest
-    if (manifest && 'theme_color' in manifest && manifest.theme_color)
-      header.themeColor = { name: 'theme-color', content: manifest.theme_color }
-  }
+  if (assetsGeneratorContext.injectThemeColor)
+    header.themeColors = resolveThemeColors(ctx)
 
   if (assetsGeneratorContext.includeHtmlHeadLinks) {
     const includeId = assetsGeneratorContext.includeId
@@ -54,4 +51,37 @@ export function resolveHtmlAssets(
   }
 
   return header
+}
+
+function resolveThemeColors(ctx: PWAPluginContext): ColorSchemeMeta[] {
+  const manifest = ctx.options.manifest
+  if (!manifest || !('theme_color' in manifest) || !manifest.theme_color)
+    return []
+
+  const themeColor: ColorSchemeMeta = {
+    name: 'theme-color',
+    content: manifest.theme_color,
+  }
+  if (
+    !('color_scheme_dark' in manifest)
+    || !manifest.color_scheme_dark
+    || !('theme_color' in manifest.color_scheme_dark)
+    || !manifest.color_scheme_dark.theme_color
+  ) {
+    return [themeColor]
+  }
+
+  themeColor.media = '(prefers-color-scheme: light)'
+  return [
+    themeColor,
+    {
+      name: 'theme-color',
+      content: manifest.color_scheme_dark.theme_color,
+      media: '(prefers-color-scheme: dark)',
+    },
+  ]
+}
+
+function colorSchemeMetaToHtml(meta: ColorSchemeMeta) {
+  return `<meta name="${meta.name}" content="${meta.content}"${meta.media ? ` media="${meta.media}"` : ''}>`
 }

--- a/src/pwa-assets/types.ts
+++ b/src/pwa-assets/types.ts
@@ -18,6 +18,7 @@ export interface PWAHtmlLink {
 export interface ColorSchemeMeta {
   name: string
   content: string
+  media?: string
 }
 
 export interface ResolvedIconAsset {
@@ -31,7 +32,7 @@ export interface ResolvedIconAsset {
 
 export interface PWAHtmlAssets {
   links: PWAHtmlLink[]
-  themeColor?: ColorSchemeMeta
+  themeColors: ColorSchemeMeta[]
 }
 
 export interface AssetsGeneratorContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,7 +473,7 @@ export interface IconResource {
   purpose?: StringLiteralUnion<IconPurpose> | IconPurpose[]
 }
 
-export interface ManifestColorScheme {
+export interface ColorSchemeDark {
   background_color?: string
   theme_color?: string
 }
@@ -545,7 +545,7 @@ export interface ManifestOptions {
   /**
    * Colors used in dark mode.
    */
-  color_scheme_dark?: ManifestColorScheme
+  color_scheme_dark?: ColorSchemeDark
   /**
    * @default `ltr`
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,6 +473,11 @@ export interface IconResource {
   purpose?: StringLiteralUnion<IconPurpose> | IconPurpose[]
 }
 
+export interface ManifestColorScheme {
+  background_color?: string
+  theme_color?: string
+}
+
 export interface ManifestOptions {
   /**
    * @default _npm_package_name_
@@ -537,6 +542,10 @@ export interface ManifestOptions {
    * @default `#42b883`
    */
   theme_color: string
+  /**
+   * Colors used in dark mode.
+   */
+  color_scheme_dark?: ManifestColorScheme
   /**
    * @default `ltr`
    */


### PR DESCRIPTION
### Description

Stacked on #941.

This expands `injectThemeColor` to also support injecting dark theme colors. When they are defined, two `meta[name="theme-color"]` tags are injected, with appropriate `media="(prefers-color-scheme: light/dark)"` attributes.

### Linked Issues

No related issues.

### Additional Context

I didn't add tests, because I couldn't find any existing ones for this feature.